### PR TITLE
Task 10121: Admin dashboard, audit logs, and PHP type safety

### DIFF
--- a/apps/backend/app/Console/Commands/GenerateVapidKeysCommand.php
+++ b/apps/backend/app/Console/Commands/GenerateVapidKeysCommand.php
@@ -9,18 +9,8 @@ use Minishlink\WebPush\VAPID;
 
 final class GenerateVapidKeysCommand extends Command
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
     protected $signature = 'webpush:generate-vapid';
 
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
     protected $description = 'Generate VAPID keys for Web Push notifications';
 
     /**

--- a/apps/backend/app/Http/Controllers/Admin/StatsController.php
+++ b/apps/backend/app/Http/Controllers/Admin/StatsController.php
@@ -69,7 +69,7 @@ final class StatsController extends Controller
             ->orderByDesc('items_count')
             ->limit(10)
             ->get()
-            ->map(function ($user) {
+            ->map(function (User $user): array {
                 return [
                     'id' => $user->id,
                     'name' => $user->name,

--- a/apps/backend/app/Http/Controllers/Admin/UserController.php
+++ b/apps/backend/app/Http/Controllers/Admin/UserController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\UserResource;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -28,7 +29,7 @@ final class UserController extends Controller
 
         if ($request->has('search')) {
             $search = $request->search;
-            $query->where(function ($q) use ($search) {
+            $query->where(function (Builder $q) use ($search): void {
                 $q->where('name', 'like', "%{$search}%")
                     ->orWhere('email', 'like', "%{$search}%");
             });

--- a/apps/backend/app/Http/Controllers/Admin/Web/DashboardController.php
+++ b/apps/backend/app/Http/Controllers/Admin/Web/DashboardController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin\Web;
+
+use App\Http\Controllers\Controller;
+use App\Services\AdminStatsService;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+final class DashboardController extends Controller
+{
+    public function __construct(
+        private readonly AdminStatsService $statsService,
+    ) {}
+
+    public function __invoke(Request $request): Response
+    {
+        return Inertia::render('admin/dashboard', [
+            'stats' => $this->statsService->getHealthPulse(),
+        ]);
+    }
+}

--- a/apps/backend/app/Http/Controllers/Admin/Web/UsersController.php
+++ b/apps/backend/app/Http/Controllers/Admin/Web/UsersController.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin\Web;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Services\AdminUserService;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+use Inertia\Response;
+
+final class UsersController extends Controller
+{
+    public function __construct(
+        private readonly AdminUserService $adminUserService,
+    ) {}
+
+    /**
+     * Display paginated, searchable user listing.
+     */
+    public function index(Request $request): Response
+    {
+        $search = $request->string('search')->trim()->value();
+        $roleFilter = $request->query('role');
+
+        $query = User::query()
+            ->withCount(['items', 'projects', 'tags'])
+            ->orderBy('created_at', 'desc');
+
+        if (mb_strlen($search) >= 2) {
+            $query->where(function (Builder $q) use ($search): void {
+                $q->where('name', 'like', "%{$search}%")
+                    ->orWhere('email', 'like', "%{$search}%")
+                    ->orWhere('phone', 'like', "%{$search}%");
+            });
+        }
+
+        if ($roleFilter === 'admin') {
+            $query->where('is_admin', true);
+        } elseif ($roleFilter === 'user') {
+            $query->where('is_admin', false);
+        }
+
+        $users = $query->paginate(25)->withQueryString();
+
+        return Inertia::render('admin/users/index', [
+            'users' => $users,
+            'filters' => [
+                'search' => $search,
+                'role' => $roleFilter,
+            ],
+        ]);
+    }
+
+    /**
+     * Display a user's full collaboration history.
+     */
+    public function show(User $user): Response
+    {
+        $user->loadCount(['items', 'projects', 'tags', 'taskNotifications']);
+
+        // Collaboration: items assigned to this user with project and owner context
+        $assignedItems = $user->assignedItems()
+            ->select(['id', 'title', 'status', 'project_id', 'user_id', 'completed_at', 'created_at'])
+            ->with([
+                'project:id,name,color',
+                'user:id,name,email',
+            ])
+            ->latest()
+            ->limit(50)
+            ->get();
+
+        // Items this user delegated to others
+        $delegatedItems = $user->items()
+            ->whereNotNull('assignee_id')
+            ->select(['id', 'title', 'status', 'project_id', 'assignee_id', 'completed_at', 'created_at'])
+            ->with([
+                'project:id,name,color',
+                'assignee:id,name,email',
+            ])
+            ->latest()
+            ->limit(50)
+            ->get();
+
+        // Shared lists (projects with items created by or assigned to other users)
+        $sharedProjects = $user->projects()
+            ->withCount('items')
+            ->with(['items' => fn ($q) => $q->whereNotNull('assignee_id')->select(['id', 'project_id', 'assignee_id'])->with('assignee:id,name')])
+            ->latest()
+            ->limit(20)
+            ->get();
+
+        return Inertia::render('admin/users/show', [
+            'user' => $user,
+            'assigned_items' => $assignedItems,
+            'delegated_items' => $delegatedItems,
+            'shared_projects' => $sharedProjects,
+        ]);
+    }
+
+    /**
+     * Update user profile or role.
+     */
+    public function update(Request $request, User $user): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['sometimes', 'string', 'max:255'],
+            'email' => ['sometimes', 'string', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
+            'phone' => ['sometimes', 'nullable', 'string', 'max:20'],
+            'notes' => ['sometimes', 'nullable', 'string', 'max:10000'],
+            'is_admin' => ['sometimes', 'boolean'],
+        ]);
+
+        $isAdminField = isset($validated['is_admin']);
+
+        if ($isAdminField) {
+            // Prevent self-demotion — cast both keys to string to handle UUID object vs string
+            if ((string) $user->getKey() === (string) $request->user()->getKey() && ! $validated['is_admin']) {
+                return back()->withErrors(['is_admin' => 'You cannot remove your own admin privileges.']);
+            }
+
+            $this->adminUserService->toggleAdminRole(
+                admin: $request->user(),
+                target: $user,
+                makeAdmin: (bool) $validated['is_admin'],
+                ipAddress: $request->ip() ?? '',
+                userAgent: $request->userAgent() ?? '',
+            );
+
+            unset($validated['is_admin']);
+        }
+
+        if (! empty($validated)) {
+            $this->adminUserService->updateProfile(
+                admin: $request->user(),
+                target: $user,
+                data: $validated,
+                ipAddress: $request->ip() ?? '',
+                userAgent: $request->userAgent() ?? '',
+            );
+        }
+
+        return back()->with('success', 'User updated successfully.');
+    }
+
+    /**
+     * Hard reset a user's data.
+     */
+    public function hardReset(Request $request, User $user): RedirectResponse
+    {
+        // Prevent self-reset — cast both keys to string to handle UUID object vs string
+        if ((string) $user->getKey() === (string) $request->user()->getKey()) {
+            return back()->withErrors(['hard_reset' => 'You cannot hard reset your own account.']);
+        }
+
+        $this->adminUserService->hardReset(
+            admin: $request->user(),
+            target: $user,
+            ipAddress: $request->ip() ?? '',
+            userAgent: $request->userAgent() ?? '',
+        );
+
+        return back()->with('success', "User {$user->name}'s data has been reset.");
+    }
+
+    /**
+     * Not used — admins do not create users through the web UI.
+     */
+    public function create(): never
+    {
+        abort(404);
+    }
+
+    /**
+     * Not used.
+     */
+    public function store(Request $request): never
+    {
+        abort(404);
+    }
+
+    /**
+     * Not used — admins do not delete users through the web UI (too destructive without review).
+     */
+    public function destroy(User $user): never
+    {
+        abort(404);
+    }
+
+    /**
+     * Not used.
+     */
+    public function edit(User $user): never
+    {
+        abort(404);
+    }
+}

--- a/apps/backend/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/apps/backend/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
@@ -11,7 +13,7 @@ use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class AuthenticatedSessionController extends Controller
+final class AuthenticatedSessionController extends Controller
 {
     /**
      * Show the login page.

--- a/apps/backend/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/apps/backend/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
@@ -10,7 +12,7 @@ use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class ConfirmablePasswordController extends Controller
+final class ConfirmablePasswordController extends Controller
 {
     /**
      * Show the confirm password page.

--- a/apps/backend/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/apps/backend/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
-class EmailVerificationNotificationController extends Controller
+final class EmailVerificationNotificationController extends Controller
 {
     /**
      * Send a new email verification notification.

--- a/apps/backend/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/apps/backend/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
@@ -8,7 +10,7 @@ use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class EmailVerificationPromptController extends Controller
+final class EmailVerificationPromptController extends Controller
 {
     /**
      * Show the email verification prompt page.

--- a/apps/backend/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/apps/backend/app/Http/Controllers/Auth/NewPasswordController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
@@ -15,7 +17,7 @@ use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class NewPasswordController extends Controller
+final class NewPasswordController extends Controller
 {
     /**
      * Show the password reset page.
@@ -46,7 +48,7 @@ class NewPasswordController extends Controller
         // database. Otherwise we will parse the error and return the response.
         $status = Password::reset(
             $request->only('email', 'password', 'password_confirmation', 'token'),
-            function (User $user) use ($request) {
+            function (User $user) use ($request): void {
                 $user->forceFill([
                     'password' => Hash::make($request->password),
                     'remember_token' => Str::random(60),

--- a/apps/backend/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/apps/backend/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
@@ -9,7 +11,7 @@ use Illuminate\Support\Facades\Password;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class PasswordResetLinkController extends Controller
+final class PasswordResetLinkController extends Controller
 {
     /**
      * Show the password reset link request page.

--- a/apps/backend/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/apps/backend/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
@@ -13,7 +15,7 @@ use Illuminate\Validation\Rules;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class RegisteredUserController extends Controller
+final class RegisteredUserController extends Controller
 {
     /**
      * Show the registration page.

--- a/apps/backend/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/apps/backend/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Http\RedirectResponse;
 
-class VerifyEmailController extends Controller
+final class VerifyEmailController extends Controller
 {
     /**
      * Mark the authenticated user's email address as verified.

--- a/apps/backend/app/Http/Controllers/ConnectionController.php
+++ b/apps/backend/app/Http/Controllers/ConnectionController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers;
 use App\Contracts\NotificationServiceInterface;
 use App\Models\Connection;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -97,10 +98,10 @@ final class ConnectionController extends Controller
         }
 
         // Check if connection already exists (either direction)
-        $existingConnection = Connection::where(function ($query) use ($currentUser, $targetUserId) {
+        $existingConnection = Connection::where(function (Builder $query) use ($currentUser, $targetUserId): void {
             $query->where('requester_id', $currentUser->id)
                 ->where('addressee_id', $targetUserId);
-        })->orWhere(function ($query) use ($currentUser, $targetUserId) {
+        })->orWhere(function (Builder $query) use ($currentUser, $targetUserId): void {
             $query->where('requester_id', $targetUserId)
                 ->where('addressee_id', $currentUser->id);
         })->first();

--- a/apps/backend/app/Http/Controllers/ItemController.php
+++ b/apps/backend/app/Http/Controllers/ItemController.php
@@ -14,6 +14,7 @@ use App\Models\User;
 use App\Policies\ItemPolicy;
 use App\Services\RecurrenceService;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -100,7 +101,7 @@ final class ItemController extends Controller
         }
 
         if ($request->has('tag_id')) {
-            $query->whereHas('tags', function ($q) use ($request) {
+            $query->whereHas('tags', function (Builder $q) use ($request): void {
                 $q->where('tags.id', $request->tag_id);
             });
         }
@@ -488,10 +489,10 @@ final class ItemController extends Controller
 
         DB::transaction(function () use ($owner, $assigneeId): void {
             // Check for any existing connection (either direction)
-            $existing = Connection::where(function ($query) use ($owner, $assigneeId) {
+            $existing = Connection::where(function (Builder $query) use ($owner, $assigneeId): void {
                 $query->where('requester_id', $owner->id)
                     ->where('addressee_id', $assigneeId);
-            })->orWhere(function ($query) use ($owner, $assigneeId) {
+            })->orWhere(function (Builder $query) use ($owner, $assigneeId): void {
                 $query->where('requester_id', $assigneeId)
                     ->where('addressee_id', $owner->id);
             })->first();

--- a/apps/backend/app/Http/Controllers/Settings/PasswordController.php
+++ b/apps/backend/app/Http/Controllers/Settings/PasswordController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Settings;
 
 use App\Http\Controllers\Controller;
@@ -10,7 +12,7 @@ use Illuminate\Validation\Rules\Password;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class PasswordController extends Controller
+final class PasswordController extends Controller
 {
     /**
      * Show the user's password settings page.

--- a/apps/backend/app/Http/Controllers/Settings/ProfileController.php
+++ b/apps/backend/app/Http/Controllers/Settings/ProfileController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Settings;
 
 use App\Http\Controllers\Controller;
@@ -11,7 +13,7 @@ use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class ProfileController extends Controller
+final class ProfileController extends Controller
 {
     /**
      * Show the user's profile settings page.

--- a/apps/backend/app/Http/Controllers/UserDiscoveryController.php
+++ b/apps/backend/app/Http/Controllers/UserDiscoveryController.php
@@ -54,7 +54,7 @@ final class UserDiscoveryController extends Controller
                 $user = User::where('id', '!=', $currentUserId)
                     ->whereNotNull('phone')
                     ->get()
-                    ->first(function ($u) use ($phoneSuffix) {
+                    ->first(function (User $u) use ($phoneSuffix): bool {
                         $userPhoneDigits = preg_replace('/[^0-9]/', '', $u->phone ?? '');
                         $userSuffix = strlen($userPhoneDigits) >= 9 ? substr($userPhoneDigits, -9) : $userPhoneDigits;
 

--- a/apps/backend/app/Http/Controllers/UserLookupController.php
+++ b/apps/backend/app/Http/Controllers/UserLookupController.php
@@ -56,7 +56,7 @@ final class UserLookupController extends Controller
             $users = User::whereIn('id', $connectedUserIds)
                 ->whereNotNull('phone')
                 ->get()
-                ->filter(function ($user) use ($phoneSuffix) {
+                ->filter(function (User $user) use ($phoneSuffix): bool {
                     // Extract digits only from phone and get last 9
                     $phoneDigits = preg_replace('/[^0-9]/', '', $user->phone ?? '');
                     $userSuffix = strlen($phoneDigits) >= 9 ? substr($phoneDigits, -9) : $phoneDigits;

--- a/apps/backend/app/Http/Middleware/EnsureUserIsAdmin.php
+++ b/apps/backend/app/Http/Middleware/EnsureUserIsAdmin.php
@@ -6,6 +6,7 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Response;
 
 final class EnsureUserIsAdmin
@@ -17,10 +18,36 @@ final class EnsureUserIsAdmin
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if (! $request->user() || ! $request->user()->is_admin) {
+        $user = $request->user();
+
+        if (! $user || ! $user->is_admin) {
+            $this->logUnauthorisedAccess($request);
+
+            // For API routes return JSON 403
+            if ($request->expectsJson() || $request->is('api/*')) {
+                return response()->json(
+                    ['message' => 'Access denied. Admin privileges required.'],
+                    Response::HTTP_FORBIDDEN,
+                );
+            }
+
+            // For web (Inertia) routes abort with 403
             abort(Response::HTTP_FORBIDDEN, 'Access denied. Admin privileges required.');
         }
 
         return $next($request);
+    }
+
+    private function logUnauthorisedAccess(Request $request): void
+    {
+        $userId = $request->user()?->id ?? 'unauthenticated';
+
+        Log::channel('security')->warning('Unauthorised admin access attempt', [
+            'user_id' => $userId,
+            'ip' => $request->ip(),
+            'user_agent' => $request->userAgent(),
+            'uri' => $request->getRequestUri(),
+            'method' => $request->method(),
+        ]);
     }
 }

--- a/apps/backend/app/Http/Middleware/HandleAppearance.php
+++ b/apps/backend/app/Http/Middleware/HandleAppearance.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Middleware;
 
 use Closure;
@@ -7,7 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\View;
 use Symfony\Component\HttpFoundation\Response;
 
-class HandleAppearance
+final class HandleAppearance
 {
     /**
      * Handle an incoming request.

--- a/apps/backend/app/Http/Middleware/HandleInertiaRequests.php
+++ b/apps/backend/app/Http/Middleware/HandleInertiaRequests.php
@@ -1,19 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Middleware;
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 
-class HandleInertiaRequests extends Middleware
+final class HandleInertiaRequests extends Middleware
 {
     /**
      * The root template that's loaded on the first page visit.
      *
      * @see https://inertiajs.com/server-side-setup#root-template
-     *
-     * @var string
      */
     protected $rootView = 'app';
 

--- a/apps/backend/app/Http/Requests/Auth/LoginRequest.php
+++ b/apps/backend/app/Http/Requests/Auth/LoginRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Auth;
 
 use Illuminate\Auth\Events\Lockout;
@@ -8,7 +10,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Validation\ValidationException;
 
-class LoginRequest extends FormRequest
+final class LoginRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/apps/backend/app/Http/Requests/Settings/ProfileUpdateRequest.php
+++ b/apps/backend/app/Http/Requests/Settings/ProfileUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Settings;
 
 use App\Models\User;
@@ -7,7 +9,7 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-class ProfileUpdateRequest extends FormRequest
+final class ProfileUpdateRequest extends FormRequest
 {
     /**
      * Get the validation rules that apply to the request.

--- a/apps/backend/app/Http/Requests/StoreItemRequest.php
+++ b/apps/backend/app/Http/Requests/StoreItemRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -32,7 +33,7 @@ final class StoreItemRequest extends FormRequest
             'project_id' => [
                 'nullable',
                 'uuid',
-                Rule::exists('projects', 'id')->where(function ($query) {
+                Rule::exists('projects', 'id')->where(function (Builder $query): void {
                     $query->where('user_id', Auth::id());
                 }),
             ],
@@ -49,7 +50,7 @@ final class StoreItemRequest extends FormRequest
             'tag_ids' => ['nullable', 'array'],
             'tag_ids.*' => [
                 'uuid',
-                Rule::exists('tags', 'id')->where(function ($query) {
+                Rule::exists('tags', 'id')->where(function (Builder $query): void {
                     $query->where('user_id', Auth::id());
                 }),
             ],

--- a/apps/backend/app/Http/Requests/StoreTagRequest.php
+++ b/apps/backend/app/Http/Requests/StoreTagRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -30,7 +31,7 @@ final class StoreTagRequest extends FormRequest
                 'required',
                 'string',
                 'max:255',
-                Rule::unique('tags')->where(function ($query) {
+                Rule::unique('tags')->where(function (Builder $query): Builder {
                     return $query->where('user_id', Auth::id());
                 }),
             ],

--- a/apps/backend/app/Http/Requests/UpdateItemRequest.php
+++ b/apps/backend/app/Http/Requests/UpdateItemRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -33,7 +34,7 @@ final class UpdateItemRequest extends FormRequest
             'project_id' => [
                 'nullable',
                 'uuid',
-                Rule::exists('projects', 'id')->where(function ($query) {
+                Rule::exists('projects', 'id')->where(function (Builder $query): void {
                     $query->where('user_id', Auth::id());
                 }),
             ],
@@ -50,7 +51,7 @@ final class UpdateItemRequest extends FormRequest
             'tag_ids' => ['nullable', 'array'],
             'tag_ids.*' => [
                 'uuid',
-                Rule::exists('tags', 'id')->where(function ($query) {
+                Rule::exists('tags', 'id')->where(function (Builder $query): void {
                     $query->where('user_id', Auth::id());
                 }),
             ],

--- a/apps/backend/app/Http/Requests/UpdateTagRequest.php
+++ b/apps/backend/app/Http/Requests/UpdateTagRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -31,7 +32,7 @@ final class UpdateTagRequest extends FormRequest
                 'required',
                 'string',
                 'max:255',
-                Rule::unique('tags')->where(function ($query) {
+                Rule::unique('tags')->where(function (Builder $query): Builder {
                     return $query->where('user_id', Auth::id());
                 })->ignore($this->route('tag')),
             ],

--- a/apps/backend/app/Models/AuditLog.php
+++ b/apps/backend/app/Models/AuditLog.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+final class AuditLog extends Model
+{
+    /** @use HasFactory<\Database\Factories\AuditLogFactory> */
+    use HasFactory, HasUuids;
+
+    /**
+     * Audit logs are append-only — there is no updated_at column.
+     * Setting this constant to null tells Eloquent to skip updated_at
+     * while still auto-populating created_at from PHP (app timezone / UTC).
+     */
+    public const UPDATED_AT = null;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'admin_id',
+        'action',
+        'subject_type',
+        'subject_id',
+        'old_values',
+        'new_values',
+        'ip_address',
+        'user_agent',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    #[\Override]
+    protected function casts(): array
+    {
+        return [
+            'old_values' => 'array',
+            'new_values' => 'array',
+        ];
+    }
+
+    public function admin(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'admin_id');
+    }
+}

--- a/apps/backend/app/Models/Item.php
+++ b/apps/backend/app/Models/Item.php
@@ -53,17 +53,17 @@ final class Item extends Model
     }
 
     #[\Override]
-    public function resolveRouteBinding($value, $field = null)
+    public function resolveRouteBinding(mixed $value, $field = null): ?static
     {
         return $this->where($field ?? $this->getRouteKeyName(), $value)->first();
     }
 
     #[\Override]
-    protected static function boot()
+    protected static function boot(): void
     {
         parent::boot();
 
-        self::creating(function ($model) {
+        self::creating(function (self $model): void {
             if (empty($model->id)) {
                 $model->id = Str::uuid();
             }

--- a/apps/backend/app/Models/Notification.php
+++ b/apps/backend/app/Models/Notification.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 final class Notification extends Model
 {
-    use HasUuids;
+    /** @use HasFactory<\Database\Factories\NotificationFactory> */
+    use HasFactory, HasUuids;
 
     protected $fillable = [
         'user_id',

--- a/apps/backend/app/Models/Project.php
+++ b/apps/backend/app/Models/Project.php
@@ -40,7 +40,7 @@ final class Project extends Model
     {
         parent::boot();
 
-        self::creating(function ($model): void {
+        self::creating(function (self $model): void {
             if (empty($model->id)) {
                 $model->id = Str::uuid();
             }

--- a/apps/backend/app/Models/Tag.php
+++ b/apps/backend/app/Models/Tag.php
@@ -34,7 +34,7 @@ final class Tag extends Model
     {
         parent::boot();
 
-        self::creating(function ($model): void {
+        self::creating(function (self $model): void {
             if (empty($model->id)) {
                 $model->id = Str::uuid();
             }

--- a/apps/backend/app/Models/User.php
+++ b/apps/backend/app/Models/User.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -82,7 +83,7 @@ final class User extends Authenticatable
     {
         parent::boot();
 
-        self::creating(function ($model): void {
+        self::creating(function (self $model): void {
             if (empty($model->id)) {
                 $model->id = Str::uuid();
             }
@@ -172,11 +173,11 @@ final class User extends Authenticatable
         $userId = $user instanceof User ? $user->id : $user;
 
         return Connection::where('status', 'accepted')
-            ->where(function ($query) use ($userId) {
-                $query->where(function ($q) use ($userId) {
+            ->where(function (Builder $query) use ($userId): void {
+                $query->where(function (Builder $q) use ($userId): void {
                     $q->where('requester_id', $this->id)
                         ->where('addressee_id', $userId);
-                })->orWhere(function ($q) use ($userId) {
+                })->orWhere(function (Builder $q) use ($userId): void {
                     $q->where('requester_id', $userId)
                         ->where('addressee_id', $this->id);
                 });

--- a/apps/backend/app/Providers/AppServiceProvider.php
+++ b/apps/backend/app/Providers/AppServiceProvider.php
@@ -39,25 +39,25 @@ final class AppServiceProvider extends ServiceProvider
     {
         // Strict rate limiting for authentication endpoints (by IP)
         // 5 attempts per minute - prevents brute force and mass account creation
-        RateLimiter::for('auth', function (Request $request) {
+        RateLimiter::for('auth', function (Request $request): Limit {
             return Limit::perMinute(5)->by($request->ip());
         });
 
         // Moderate rate limiting for user discovery/lookup (by authenticated user)
         // 30 attempts per minute - prevents enumeration attacks
-        RateLimiter::for('user-search', function (Request $request) {
+        RateLimiter::for('user-search', function (Request $request): Limit {
             return Limit::perMinute(30)->by($request->user()?->id ?: $request->ip());
         });
 
         // Rate limiting for connection requests (by authenticated user)
         // 10 attempts per minute - prevents spam connection requests
-        RateLimiter::for('connections', function (Request $request) {
+        RateLimiter::for('connections', function (Request $request): Limit {
             return Limit::perMinute(10)->by($request->user()?->id ?: $request->ip());
         });
 
         // General API rate limiting (by authenticated user or IP)
         // 60 requests per minute for normal operations
-        RateLimiter::for('api', function (Request $request) {
+        RateLimiter::for('api', function (Request $request): Limit {
             return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
         });
     }

--- a/apps/backend/app/Providers/AuthServiceProvider.php
+++ b/apps/backend/app/Providers/AuthServiceProvider.php
@@ -7,10 +7,12 @@ namespace App\Providers;
 use App\Models\Item;
 use App\Models\Project;
 use App\Models\Tag;
+use App\Models\User;
 use App\Policies\ItemPolicy;
 use App\Policies\ProjectPolicy;
 use App\Policies\TagPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
 
 final class AuthServiceProvider extends ServiceProvider
 {
@@ -31,5 +33,7 @@ final class AuthServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->registerPolicies();
+
+        Gate::define('admin', fn (User $user): bool => $user->is_admin);
     }
 }

--- a/apps/backend/app/Services/AdminStatsService.php
+++ b/apps/backend/app/Services/AdminStatsService.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Item;
+use App\Models\Notification;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+final class AdminStatsService
+{
+    private const int CACHE_TTL = 60;
+
+    /**
+     * Get the Health Pulse stats, cached for 60 seconds.
+     *
+     * @return array<string, mixed>
+     */
+    public function getHealthPulse(): array
+    {
+        return Cache::remember('admin.health_pulse', self::CACHE_TTL, function (): array {
+            return [
+                'users' => $this->getUserStats(),
+                'content' => $this->getContentStats(),
+                'growth' => $this->getGrowthStats(),
+                'queue' => $this->getQueueHealth(),
+            ];
+        });
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getUserStats(): array
+    {
+        return [
+            'total' => User::count(),
+            'admins' => User::where('is_admin', true)->count(),
+            'verified' => User::whereNotNull('email_verified_at')->count(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getContentStats(): array
+    {
+        return [
+            'active_todos' => Item::whereIn('status', ['todo', 'doing'])->count(),
+            'active_lists' => Project::whereNull('archived_at')->count(),
+            'total_items' => Item::count(),
+            'items_by_status' => [
+                'todo' => Item::where('status', 'todo')->count(),
+                'doing' => Item::where('status', 'doing')->count(),
+                'done' => Item::where('status', 'done')->count(),
+                'wontdo' => Item::where('status', 'wontdo')->count(),
+            ],
+        ];
+    }
+
+    /**
+     * 24-hour growth metrics.
+     *
+     * @return array<string, int>
+     */
+    private function getGrowthStats(): array
+    {
+        $since = now()->subHours(24);
+
+        return [
+            'new_users_24h' => User::where('created_at', '>=', $since)->count(),
+            'new_items_24h' => Item::where('created_at', '>=', $since)->count(),
+            'completed_items_24h' => Item::where('completed_at', '>=', $since)->count(),
+        ];
+    }
+
+    /**
+     * Notification queue health: pending unread vs failed jobs.
+     *
+     * @return array<string, int>
+     */
+    private function getQueueHealth(): array
+    {
+        $pendingJobs = DB::table('jobs')->count();
+        $failedJobs = DB::table('failed_jobs')->count();
+        $pendingNotifications = Notification::whereNull('read_at')->count();
+
+        return [
+            'pending_jobs' => $pendingJobs,
+            'failed_jobs' => $failedJobs,
+            'pending_notifications' => $pendingNotifications,
+        ];
+    }
+}

--- a/apps/backend/app/Services/AdminUserService.php
+++ b/apps/backend/app/Services/AdminUserService.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+final class AdminUserService
+{
+    public function __construct(
+        private readonly AuditLogService $auditLogService,
+    ) {}
+
+    /**
+     * Hard reset: wipe all data owned by or assigned to the user, keep the account.
+     *
+     * The target row is locked for update at the start of the transaction so
+     * that concurrent hard-resets on the same user queue behind each other
+     * rather than racing and producing duplicate audit entries.
+     *
+     * All relationship counts are fetched in a single loadCount() query
+     * (one correlated subquery per relationship) instead of six separate
+     * COUNT(*) round-trips.
+     */
+    public function hardReset(User $admin, User $target, string $ipAddress, string $userAgent): void
+    {
+        DB::transaction(function () use ($admin, $target, $ipAddress, $userAgent): void {
+            // Re-fetch with an exclusive row lock so concurrent resets on the
+            // same user serialise rather than interleave their reads and deletes.
+            $target = User::lockForUpdate()->findOrFail($target->getKey());
+
+            // Single query: one SELECT with six correlated COUNT subqueries.
+            $target->loadCount([
+                'items',
+                'projects',
+                'tags',
+                'taskNotifications',
+                'sentConnectionRequests',
+                'receivedConnectionRequests',
+            ]);
+
+            $oldValues = [
+                'items_count' => $target->items_count,
+                'projects_count' => $target->projects_count,
+                'tags_count' => $target->tags_count,
+                'notifications_count' => $target->task_notifications_count,
+                'connections_count' => $target->sent_connection_requests_count + $target->received_connection_requests_count,
+            ];
+
+            // Wipe items (force delete to bypass soft deletes)
+            $target->items()->forceDelete();
+
+            // Wipe assigned items references (nullify assignee)
+            $target->assignedItems()->update(['assignee_id' => null]);
+
+            // Wipe projects (cascades to items via FK or we handle it via forceDelete above)
+            $target->projects()->forceDelete();
+
+            // Wipe tags
+            $target->tags()->delete();
+
+            // Wipe notifications
+            $target->taskNotifications()->delete();
+
+            // Wipe connections (both directions)
+            $target->sentConnectionRequests()->delete();
+            $target->receivedConnectionRequests()->delete();
+
+            // Wipe push subscriptions
+            $target->pushSubscriptions()->delete();
+
+            // Revoke all Sanctum tokens
+            $target->tokens()->delete();
+
+            $this->auditLogService->log(
+                admin: $admin,
+                action: 'user.hard_reset',
+                subjectType: 'user',
+                subjectId: (string) $target->getKey(),
+                oldValues: $oldValues,
+                ipAddress: $ipAddress,
+                userAgent: $userAgent,
+            );
+        });
+    }
+
+    /**
+     * Toggle the admin role for a user.
+     *
+     * Wrapped in a transaction with a row lock so that two concurrent
+     * role-toggles on the same user cannot both read the same old value
+     * and produce conflicting audit entries.
+     */
+    public function toggleAdminRole(User $admin, User $target, bool $makeAdmin, string $ipAddress, string $userAgent): void
+    {
+        DB::transaction(function () use ($admin, $target, $makeAdmin, $ipAddress, $userAgent): void {
+            $target = User::lockForUpdate()->findOrFail($target->getKey());
+
+            $oldValues = ['is_admin' => $target->is_admin];
+            $target->update(['is_admin' => $makeAdmin]);
+
+            $this->auditLogService->log(
+                admin: $admin,
+                action: 'user.role_changed',
+                subjectType: 'user',
+                subjectId: (string) $target->getKey(),
+                oldValues: $oldValues,
+                newValues: ['is_admin' => $makeAdmin],
+                ipAddress: $ipAddress,
+                userAgent: $userAgent,
+            );
+        });
+    }
+
+    /**
+     * Update user profile fields (name, email, phone, notes).
+     *
+     * Wrapped in a transaction with a row lock so the old-value snapshot
+     * and the write are always consistent.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function updateProfile(User $admin, User $target, array $data, string $ipAddress, string $userAgent): void
+    {
+        DB::transaction(function () use ($admin, $target, $data, $ipAddress, $userAgent): void {
+            $target = User::lockForUpdate()->findOrFail($target->getKey());
+
+            $oldValues = $target->only(array_keys($data));
+            $target->update($data);
+
+            $this->auditLogService->log(
+                admin: $admin,
+                action: 'user.profile_updated',
+                subjectType: 'user',
+                subjectId: (string) $target->getKey(),
+                oldValues: $oldValues,
+                newValues: $data,
+                ipAddress: $ipAddress,
+                userAgent: $userAgent,
+            );
+        });
+    }
+}

--- a/apps/backend/app/Services/AuditLogService.php
+++ b/apps/backend/app/Services/AuditLogService.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\AuditLog;
+use App\Models\User;
+
+final class AuditLogService
+{
+    /**
+     * Record an admin action in the audit log.
+     *
+     * ip_address and user_agent are written in the same INSERT so there is
+     * never a window where the record exists without them.
+     */
+    public function log(
+        User $admin,
+        string $action,
+        string $subjectType,
+        string $subjectId,
+        ?array $oldValues = null,
+        ?array $newValues = null,
+        string $ipAddress = '',
+        string $userAgent = '',
+    ): AuditLog {
+        return AuditLog::create([
+            'admin_id' => (string) $admin->getKey(),
+            'action' => $action,
+            'subject_type' => $subjectType,
+            'subject_id' => $subjectId,
+            'old_values' => $oldValues,
+            'new_values' => $newValues,
+            'ip_address' => $ipAddress ?: null,
+            'user_agent' => $userAgent ?: null,
+        ]);
+    }
+}

--- a/apps/backend/config/logging.php
+++ b/apps/backend/config/logging.php
@@ -118,6 +118,14 @@ return [
             'replace_placeholders' => true,
         ],
 
+        'security' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/security.log'),
+            'level' => 'warning',
+            'days' => 90,
+            'replace_placeholders' => true,
+        ],
+
         'null' => [
             'driver' => 'monolog',
             'handler' => NullHandler::class,

--- a/apps/backend/database/factories/AuditLogFactory.php
+++ b/apps/backend/database/factories/AuditLogFactory.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\AuditLog>
+ */
+final class AuditLogFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'admin_id' => User::factory()->admin(),
+            'action' => fake()->randomElement(['user.hard_reset', 'user.role_changed', 'user.profile_updated']),
+            'subject_type' => 'user',
+            'subject_id' => fake()->uuid(),
+            'old_values' => null,
+            'new_values' => null,
+            'ip_address' => fake()->ipv4(),
+            'user_agent' => fake()->userAgent(),
+        ];
+    }
+
+    public function hardReset(): static
+    {
+        return $this->state(fn () => [
+            'action' => 'user.hard_reset',
+            'old_values' => [
+                'items_count' => fake()->numberBetween(0, 100),
+                'projects_count' => fake()->numberBetween(0, 20),
+                'tags_count' => fake()->numberBetween(0, 50),
+                'notifications_count' => fake()->numberBetween(0, 200),
+                'connections_count' => fake()->numberBetween(0, 30),
+            ],
+        ]);
+    }
+
+    public function roleChanged(): static
+    {
+        return $this->state(fn () => [
+            'action' => 'user.role_changed',
+            'old_values' => ['is_admin' => false],
+            'new_values' => ['is_admin' => true],
+        ]);
+    }
+
+    public function profileUpdated(): static
+    {
+        return $this->state(fn () => [
+            'action' => 'user.profile_updated',
+            'old_values' => ['name' => fake()->name()],
+            'new_values' => ['name' => fake()->name()],
+        ]);
+    }
+}

--- a/apps/backend/database/factories/NotificationFactory.php
+++ b/apps/backend/database/factories/NotificationFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Notification>
+ */
+final class NotificationFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'type' => 'task_assigned',
+            'title' => fake()->sentence(3),
+            'message' => fake()->sentence(),
+        ];
+    }
+}

--- a/apps/backend/database/migrations/2026_02_07_021841_create_audit_logs_table.php
+++ b/apps/backend/database/migrations/2026_02_07_021841_create_audit_logs_table.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('admin_id')->constrained('users')->cascadeOnDelete();
+            $table->string('action');
+            $table->string('subject_type');
+            $table->uuid('subject_id');
+            $table->json('old_values')->nullable();
+            $table->json('new_values')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['admin_id', 'created_at']);
+            $table->index(['subject_type', 'subject_id']);
+            $table->index('action');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/apps/backend/database/migrations/2026_02_07_021842_add_performance_indexes_to_users_table.php
+++ b/apps/backend/database/migrations/2026_02_07_021842_add_performance_indexes_to_users_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // Index for search on name (fragment search performance)
+            $table->index('name');
+            // Index for default sort by created_at desc (admin user listing)
+            $table->index('created_at');
+            // Index for filtering by admin role
+            $table->index('is_admin');
+            // Note: phone index already exists from 2026_01_25_122700_add_phone_to_users_table
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex(['name']);
+            $table->dropIndex(['created_at']);
+            $table->dropIndex(['is_admin']);
+        });
+    }
+};

--- a/apps/backend/database/seeders/DatabaseSeeder.php
+++ b/apps/backend/database/seeders/DatabaseSeeder.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Seeders;
 
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
-class DatabaseSeeder extends Seeder
+final class DatabaseSeeder extends Seeder
 {
     /**
      * Seed the application's database.

--- a/apps/backend/docker-compose.yml
+++ b/apps/backend/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-    laravel.test:
+    model_b:
         build:
             context: './vendor/laravel/sail/runtimes/8.4'
             dockerfile: Dockerfile

--- a/apps/backend/resources/js/components/admin-sidebar.tsx
+++ b/apps/backend/resources/js/components/admin-sidebar.tsx
@@ -1,0 +1,58 @@
+import { NavMain } from '@/components/nav-main';
+import { NavUser } from '@/components/nav-user';
+import { Separator } from '@/components/ui/separator';
+import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
+import { type NavItem } from '@/types';
+import { Link } from '@inertiajs/react';
+import { LayoutGrid, Settings, Users } from 'lucide-react';
+import AppLogo from './app-logo';
+
+const adminNavItems: NavItem[] = [
+    {
+        title: 'Health Pulse',
+        href: '/admin',
+        icon: LayoutGrid,
+    },
+    {
+        title: 'Users',
+        href: '/admin/users',
+        icon: Users,
+    },
+];
+
+export function AdminSidebar() {
+    return (
+        <Sidebar collapsible="icon" variant="inset">
+            <SidebarHeader>
+                <SidebarMenu>
+                    <SidebarMenuItem>
+                        <SidebarMenuButton size="lg" asChild>
+                            <Link href="/admin" prefetch>
+                                <AppLogo />
+                            </Link>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+                </SidebarMenu>
+            </SidebarHeader>
+
+            <SidebarContent>
+                <NavMain items={adminNavItems} label="Administration" />
+            </SidebarContent>
+
+            <SidebarFooter>
+                <SidebarMenu>
+                    <SidebarMenuItem>
+                        <SidebarMenuButton asChild tooltip={{ children: 'Settings' }}>
+                            <Link href="/settings/profile" prefetch>
+                                <Settings />
+                                <span>Settings</span>
+                            </Link>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+                </SidebarMenu>
+                <Separator className="my-1" />
+                <NavUser />
+            </SidebarFooter>
+        </Sidebar>
+    );
+}

--- a/apps/backend/resources/js/components/nav-main.tsx
+++ b/apps/backend/resources/js/components/nav-main.tsx
@@ -2,11 +2,11 @@ import { SidebarGroup, SidebarGroupLabel, SidebarMenu, SidebarMenuButton, Sideba
 import { type NavItem } from '@/types';
 import { Link, usePage } from '@inertiajs/react';
 
-export function NavMain({ items = [] }: { items: NavItem[] }) {
+export function NavMain({ items = [], label = 'Platform' }: { items: NavItem[]; label?: string }) {
     const page = usePage();
     return (
         <SidebarGroup className="px-2 py-0">
-            <SidebarGroupLabel>Platform</SidebarGroupLabel>
+            <SidebarGroupLabel>{label}</SidebarGroupLabel>
             <SidebarMenu>
                 {items.map((item) => (
                     <SidebarMenuItem key={item.title}>

--- a/apps/backend/resources/js/layouts/admin-layout.tsx
+++ b/apps/backend/resources/js/layouts/admin-layout.tsx
@@ -1,0 +1,22 @@
+import { AdminSidebar } from '@/components/admin-sidebar';
+import { AppContent } from '@/components/app-content';
+import { AppShell } from '@/components/app-shell';
+import { AppSidebarHeader } from '@/components/app-sidebar-header';
+import { type BreadcrumbItem } from '@/types';
+import { type PropsWithChildren } from 'react';
+
+interface AdminLayoutProps {
+    breadcrumbs?: BreadcrumbItem[];
+}
+
+export default function AdminLayout({ children, breadcrumbs = [] }: PropsWithChildren<AdminLayoutProps>) {
+    return (
+        <AppShell variant="sidebar">
+            <AdminSidebar />
+            <AppContent variant="sidebar" className="overflow-x-hidden">
+                <AppSidebarHeader breadcrumbs={breadcrumbs} />
+                {children}
+            </AppContent>
+        </AppShell>
+    );
+}

--- a/apps/backend/resources/js/pages/admin/dashboard.tsx
+++ b/apps/backend/resources/js/pages/admin/dashboard.tsx
@@ -1,0 +1,146 @@
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import AdminLayout from '@/layouts/admin-layout';
+import { type AdminStats, type BreadcrumbItem, type SharedData } from '@/types';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { Activity, AlertTriangle, CheckCircle2, Settings, Shield, TrendingUp, Users } from 'lucide-react';
+
+interface Props {
+    stats: AdminStats;
+}
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Admin', href: '/admin' },
+    { title: 'Health Pulse', href: '/admin' },
+];
+
+export default function AdminDashboard({ stats }: Props) {
+    const { auth } = usePage<SharedData>().props;
+    const queueHealthy = stats.queue.failed_jobs === 0;
+
+    return (
+        <AdminLayout breadcrumbs={breadcrumbs}>
+            <Head title="Health Pulse — Admin" />
+            <div className="flex flex-col gap-6 p-4">
+                {/* Welcome header */}
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <div className="flex items-center gap-2">
+                            <h1 className="text-2xl font-bold tracking-tight">Welcome back, {auth.user.name}</h1>
+                            <Badge className="bg-ballistic-indigo text-white">
+                                <Shield className="mr-1 size-3" />
+                                Admin
+                            </Badge>
+                        </div>
+                        <p className="text-sm text-muted-foreground">Here's the platform health at a glance.</p>
+                    </div>
+                    {/* Quick actions */}
+                    <div className="flex gap-2">
+                        <Link
+                            href="/admin/users"
+                            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted"
+                        >
+                            <Users className="size-4" />
+                            Manage Users
+                        </Link>
+                        <Link
+                            href="/settings/profile"
+                            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted"
+                        >
+                            <Settings className="size-4" />
+                            Settings
+                        </Link>
+                    </div>
+                </div>
+
+                {/* Users & Growth */}
+                <section>
+                    <h2 className="mb-3 text-sm font-semibold tracking-wider text-muted-foreground uppercase">Users</h2>
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                        <StatCard title="Total Users" value={stats.users.total} icon={<Users className="size-4" />} />
+                        <StatCard title="Admins" value={stats.users.admins} icon={<Users className="size-4" />} muted />
+                        <StatCard title="Verified" value={stats.users.verified} icon={<CheckCircle2 className="size-4" />} muted />
+                        <StatCard
+                            title="New (24h)"
+                            value={stats.growth.new_users_24h}
+                            icon={<TrendingUp className="size-4" />}
+                            highlight={stats.growth.new_users_24h > 0}
+                        />
+                    </div>
+                </section>
+
+                {/* Content */}
+                <section>
+                    <h2 className="mb-3 text-sm font-semibold tracking-wider text-muted-foreground uppercase">Content</h2>
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                        <StatCard title="Active Todos" value={stats.content.active_todos} icon={<Activity className="size-4" />} />
+                        <StatCard title="Active Lists" value={stats.content.active_lists} icon={<Activity className="size-4" />} muted />
+                        <StatCard title="New Items (24h)" value={stats.growth.new_items_24h} icon={<TrendingUp className="size-4" />} />
+                        <StatCard
+                            title="Completed (24h)"
+                            value={stats.growth.completed_items_24h}
+                            icon={<CheckCircle2 className="size-4" />}
+                            highlight={stats.growth.completed_items_24h > 0}
+                        />
+                    </div>
+                </section>
+
+                {/* Item Status Breakdown */}
+                <section>
+                    <h2 className="mb-3 text-sm font-semibold tracking-wider text-muted-foreground uppercase">Item Status Breakdown</h2>
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                        <StatCard title="Todo" value={stats.content.items_by_status.todo} muted />
+                        <StatCard title="Doing" value={stats.content.items_by_status.doing} muted />
+                        <StatCard title="Done" value={stats.content.items_by_status.done} muted />
+                        <StatCard title="Won't Do" value={stats.content.items_by_status.wontdo} muted />
+                    </div>
+                </section>
+
+                {/* Queue Health */}
+                <section>
+                    <h2 className="mb-3 text-sm font-semibold tracking-wider text-muted-foreground uppercase">Notification Queue Health</h2>
+                    <div className="grid gap-4 sm:grid-cols-3">
+                        <StatCard title="Pending Jobs" value={stats.queue.pending_jobs} icon={<Activity className="size-4" />} />
+                        <StatCard
+                            title="Failed Jobs"
+                            value={stats.queue.failed_jobs}
+                            icon={queueHealthy ? <CheckCircle2 className="size-4" /> : <AlertTriangle className="size-4" />}
+                            danger={stats.queue.failed_jobs > 0}
+                        />
+                        <StatCard
+                            title="Pending Notifications"
+                            value={stats.queue.pending_notifications}
+                            icon={<Activity className="size-4" />}
+                            muted
+                        />
+                    </div>
+                </section>
+            </div>
+        </AdminLayout>
+    );
+}
+
+interface StatCardProps {
+    title: string;
+    value: number;
+    icon?: React.ReactNode;
+    muted?: boolean;
+    highlight?: boolean;
+    danger?: boolean;
+}
+
+function StatCard({ title, value, icon, muted, highlight, danger }: StatCardProps) {
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-sm font-medium">{title}</CardTitle>
+                <span className={danger ? 'text-destructive' : highlight ? 'text-ballistic-sky' : 'text-muted-foreground'}>{icon}</span>
+            </CardHeader>
+            <CardContent>
+                <div className={`text-2xl font-bold ${danger ? 'text-destructive' : muted ? 'text-muted-foreground' : ''}`}>
+                    {value.toLocaleString()}
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/apps/backend/resources/js/pages/admin/users/index.tsx
+++ b/apps/backend/resources/js/pages/admin/users/index.tsx
@@ -1,0 +1,146 @@
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import AdminLayout from '@/layouts/admin-layout';
+import { type AdminUser, type BreadcrumbItem, type PaginatedResponse } from '@/types';
+import { Head, Link, router } from '@inertiajs/react';
+import { Search } from 'lucide-react';
+import { useCallback, useState } from 'react';
+
+interface Props {
+    users: PaginatedResponse<AdminUser>;
+    filters: {
+        search: string;
+        role: string | null;
+    };
+}
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Admin', href: '/admin' },
+    { title: 'Users', href: '/admin/users' },
+];
+
+export default function AdminUsersIndex({ users, filters }: Props) {
+    const [search, setSearch] = useState(filters.search ?? '');
+
+    const handleSearch = useCallback(
+        (value: string) => {
+            setSearch(value);
+            router.get('/admin/users', { search: value, role: filters.role ?? '' }, { preserveState: true, replace: true });
+        },
+        [filters.role],
+    );
+
+    return (
+        <AdminLayout breadcrumbs={breadcrumbs}>
+            <Head title="Users — Admin" />
+            <div className="flex flex-col gap-4 p-4">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h1 className="text-2xl font-bold tracking-tight">Users</h1>
+                        <p className="text-sm text-muted-foreground">{users.total.toLocaleString()} total users</p>
+                    </div>
+
+                    {/* Role filter */}
+                    <div className="flex gap-2">
+                        {(['all', 'admin', 'user'] as const).map((role) => (
+                            <Link
+                                key={role}
+                                href={`/admin/users?role=${role === 'all' ? '' : role}&search=${search}`}
+                                className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                                    (role === 'all' && !filters.role) || filters.role === role
+                                        ? 'bg-primary text-primary-foreground'
+                                        : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
+                                }`}
+                            >
+                                {role.charAt(0).toUpperCase() + role.slice(1)}
+                            </Link>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Search */}
+                <div className="relative">
+                    <Search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                        className="pl-9"
+                        placeholder="Search by name, email or phone…"
+                        value={search}
+                        onChange={(e) => handleSearch(e.target.value)}
+                    />
+                </div>
+
+                {/* Table */}
+                <div className="rounded-lg border">
+                    <table className="w-full text-sm">
+                        <thead className="border-b bg-muted/50">
+                            <tr>
+                                <th className="px-4 py-3 text-left font-medium">Name</th>
+                                <th className="hidden px-4 py-3 text-left font-medium sm:table-cell">Email</th>
+                                <th className="hidden px-4 py-3 text-left font-medium lg:table-cell">Phone</th>
+                                <th className="px-4 py-3 text-right font-medium">Items</th>
+                                <th className="hidden px-4 py-3 text-right font-medium sm:table-cell">Projects</th>
+                                <th className="px-4 py-3 text-left font-medium">Role</th>
+                                <th className="px-4 py-3 text-left font-medium">Joined</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y">
+                            {users.data.map((user) => (
+                                <tr key={user.id} className="transition-colors hover:bg-muted/30">
+                                    <td className="px-4 py-3">
+                                        <Link href={`/admin/users/${user.id}`} className="font-medium hover:underline">
+                                            {user.name}
+                                        </Link>
+                                    </td>
+                                    <td className="hidden px-4 py-3 text-muted-foreground sm:table-cell">{user.email}</td>
+                                    <td className="hidden px-4 py-3 text-muted-foreground lg:table-cell">{user.phone ?? '—'}</td>
+                                    <td className="px-4 py-3 text-right tabular-nums">{user.items_count}</td>
+                                    <td className="hidden px-4 py-3 text-right tabular-nums sm:table-cell">{user.projects_count}</td>
+                                    <td className="px-4 py-3">
+                                        {user.is_admin ? (
+                                            <Badge className="bg-ballistic-indigo text-white">Admin</Badge>
+                                        ) : (
+                                            <Badge variant="secondary">User</Badge>
+                                        )}
+                                    </td>
+                                    <td className="px-4 py-3 text-muted-foreground tabular-nums">{new Date(user.created_at).toLocaleDateString()}</td>
+                                </tr>
+                            ))}
+                            {users.data.length === 0 && (
+                                <tr>
+                                    <td colSpan={7} className="px-4 py-8 text-center text-muted-foreground">
+                                        No users found.
+                                    </td>
+                                </tr>
+                            )}
+                        </tbody>
+                    </table>
+                </div>
+
+                {/* Pagination */}
+                {users.last_page > 1 && (
+                    <div className="flex items-center justify-between">
+                        <span className="text-sm text-muted-foreground">
+                            Showing {users.from}–{users.to} of {users.total}
+                        </span>
+                        <div className="flex gap-1">
+                            {users.links.map((link, i) => (
+                                <Link
+                                    key={i}
+                                    href={link.url ?? '#'}
+                                    className={`rounded px-3 py-1.5 text-sm ${
+                                        link.active
+                                            ? 'bg-primary text-primary-foreground'
+                                            : link.url
+                                              ? 'text-foreground hover:bg-muted'
+                                              : 'cursor-not-allowed text-muted-foreground opacity-50'
+                                    }`}
+                                    dangerouslySetInnerHTML={{ __html: link.label }}
+                                />
+                            ))}
+                        </div>
+                    </div>
+                )}
+            </div>
+        </AdminLayout>
+    );
+}

--- a/apps/backend/resources/js/pages/admin/users/show.tsx
+++ b/apps/backend/resources/js/pages/admin/users/show.tsx
@@ -1,0 +1,219 @@
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import AdminLayout from '@/layouts/admin-layout';
+import { type AdminUser, type BreadcrumbItem, type CollaborationItem } from '@/types';
+import { Head, router, useForm } from '@inertiajs/react';
+import { AlertTriangle, CheckCircle2, FolderOpen, User as UserIcon } from 'lucide-react';
+
+interface SharedProject {
+    id: string;
+    name: string;
+    color: string;
+    items_count: number;
+}
+
+interface Props {
+    user: AdminUser & { notifications_count?: number };
+    assigned_items: CollaborationItem[];
+    delegated_items: CollaborationItem[];
+    shared_projects: SharedProject[];
+}
+
+export default function AdminUserShow({ user, assigned_items, delegated_items, shared_projects }: Props) {
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: 'Admin', href: '/admin' },
+        { title: 'Users', href: '/admin/users' },
+        { title: user.name, href: `/admin/users/${user.id}` },
+    ];
+
+    const { processing, errors } = useForm({});
+
+    function toggleAdmin() {
+        router.patch(`/admin/users/${user.id}`, { is_admin: !user.is_admin }, { preserveScroll: true });
+    }
+
+    function hardReset() {
+        if (!confirm(`Hard reset ${user.name}? This will permanently delete ALL their data. This cannot be undone.`)) return;
+        router.post(`/admin/users/${user.id}/hard-reset`, {}, { preserveScroll: true });
+    }
+
+    return (
+        <AdminLayout breadcrumbs={breadcrumbs}>
+            <Head title={`${user.name} — Admin`} />
+            <div className="flex flex-col gap-6 p-4">
+                {/* Header */}
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex items-center gap-3">
+                        <div className="flex size-12 items-center justify-center rounded-full bg-primary/10">
+                            <UserIcon className="size-6 text-primary" />
+                        </div>
+                        <div>
+                            <h1 className="text-2xl font-bold">{user.name}</h1>
+                            <p className="text-sm text-muted-foreground">{user.email}</p>
+                        </div>
+                        {user.is_admin ? <Badge className="bg-ballistic-indigo text-white">Admin</Badge> : <Badge variant="secondary">User</Badge>}
+                    </div>
+
+                    {/* Actions */}
+                    <div className="flex gap-2">
+                        <button
+                            type="button"
+                            onClick={toggleAdmin}
+                            disabled={processing}
+                            className="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted disabled:opacity-50"
+                        >
+                            {user.is_admin ? 'Remove Admin' : 'Make Admin'}
+                        </button>
+                        <button
+                            type="button"
+                            onClick={hardReset}
+                            disabled={processing}
+                            className="rounded-md bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground transition-colors hover:bg-destructive/90 disabled:opacity-50"
+                        >
+                            Hard Reset
+                        </button>
+                    </div>
+                </div>
+
+                {errors.hard_reset && <div className="rounded-md bg-destructive/10 px-4 py-2 text-sm text-destructive">{errors.hard_reset}</div>}
+                {errors.is_admin && <div className="rounded-md bg-destructive/10 px-4 py-2 text-sm text-destructive">{errors.is_admin}</div>}
+
+                {/* Stats row */}
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                    <MiniStat label="Items" value={user.items_count} />
+                    <MiniStat label="Projects" value={user.projects_count} />
+                    <MiniStat label="Tags" value={user.tags_count} />
+                    <MiniStat label="Notifications" value={user.notifications_count ?? 0} />
+                </div>
+
+                {/* Profile details */}
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base">Profile</CardTitle>
+                    </CardHeader>
+                    <CardContent className="grid gap-2 text-sm">
+                        <Row label="Email" value={user.email} />
+                        <Row label="Phone" value={user.phone ?? '—'} />
+                        <Row
+                            label="Verified"
+                            value={user.email_verified_at ? new Date(user.email_verified_at).toLocaleDateString() : 'Not verified'}
+                        />
+                        <Row label="Joined" value={new Date(user.created_at).toLocaleDateString()} />
+                        {user.notes && <Row label="Notes" value={user.notes} />}
+                    </CardContent>
+                </Card>
+
+                {/* Collaboration History */}
+                <div className="grid gap-6 lg:grid-cols-2">
+                    {/* Items assigned to this user */}
+                    <Card>
+                        <CardHeader className="flex flex-row items-center gap-2">
+                            <CheckCircle2 className="size-4 text-muted-foreground" />
+                            <CardTitle className="text-base">Assigned to Me ({assigned_items.length})</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            {assigned_items.length === 0 ? (
+                                <p className="text-sm text-muted-foreground">No items assigned.</p>
+                            ) : (
+                                <ul className="divide-y text-sm">
+                                    {assigned_items.map((item) => (
+                                        <li key={item.id} className="flex items-center justify-between gap-2 py-2">
+                                            <span className="truncate font-medium">{item.title}</span>
+                                            <div className="flex shrink-0 items-center gap-2">
+                                                {item.project && (
+                                                    <span
+                                                        className="rounded px-1.5 py-0.5 text-xs text-white"
+                                                        style={{ backgroundColor: item.project.color }}
+                                                    >
+                                                        {item.project.name}
+                                                    </span>
+                                                )}
+                                                <StatusDot status={item.status} />
+                                            </div>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    {/* Items delegated by this user */}
+                    <Card>
+                        <CardHeader className="flex flex-row items-center gap-2">
+                            <AlertTriangle className="size-4 text-muted-foreground" />
+                            <CardTitle className="text-base">Delegated by Me ({delegated_items.length})</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            {delegated_items.length === 0 ? (
+                                <p className="text-sm text-muted-foreground">No delegated items.</p>
+                            ) : (
+                                <ul className="divide-y text-sm">
+                                    {delegated_items.map((item) => (
+                                        <li key={item.id} className="flex items-center justify-between gap-2 py-2">
+                                            <span className="truncate font-medium">{item.title}</span>
+                                            <div className="flex shrink-0 items-center gap-2">
+                                                {item.assignee && <span className="text-xs text-muted-foreground">→ {item.assignee.name}</span>}
+                                                <StatusDot status={item.status} />
+                                            </div>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </CardContent>
+                    </Card>
+                </div>
+
+                {/* Shared Lists */}
+                <Card>
+                    <CardHeader className="flex flex-row items-center gap-2">
+                        <FolderOpen className="size-4 text-muted-foreground" />
+                        <CardTitle className="text-base">Projects ({shared_projects.length})</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        {shared_projects.length === 0 ? (
+                            <p className="text-sm text-muted-foreground">No projects.</p>
+                        ) : (
+                            <ul className="divide-y text-sm">
+                                {shared_projects.map((project) => (
+                                    <li key={project.id} className="flex items-center gap-3 py-2">
+                                        <span className="size-3 rounded-full" style={{ backgroundColor: project.color }} />
+                                        <span className="font-medium">{project.name}</span>
+                                        <span className="ml-auto text-muted-foreground">{project.items_count} items</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </CardContent>
+                </Card>
+            </div>
+        </AdminLayout>
+    );
+}
+
+function MiniStat({ label, value }: { label: string; value: number }) {
+    return (
+        <div className="rounded-lg border p-3">
+            <div className="text-xs text-muted-foreground">{label}</div>
+            <div className="text-xl font-bold tabular-nums">{value.toLocaleString()}</div>
+        </div>
+    );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+    return (
+        <div className="flex gap-2">
+            <span className="w-24 shrink-0 text-muted-foreground">{label}</span>
+            <span>{value}</span>
+        </div>
+    );
+}
+
+function StatusDot({ status }: { status: string }) {
+    const colours: Record<string, string> = {
+        todo: 'bg-muted-foreground',
+        doing: 'bg-ballistic-sky',
+        done: 'bg-green-500',
+        wontdo: 'bg-destructive',
+    };
+    return <span className={`size-2 rounded-full ${colours[status] ?? 'bg-muted-foreground'}`} />;
+}

--- a/apps/backend/resources/js/pages/dashboard.tsx
+++ b/apps/backend/resources/js/pages/dashboard.tsx
@@ -1,34 +1,43 @@
-import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import AppLayout from '@/layouts/app-layout';
-import { dashboard } from '@/routes';
-import { type BreadcrumbItem } from '@/types';
-import { Head } from '@inertiajs/react';
+import { type BreadcrumbItem, type SharedData } from '@/types';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { Settings, Shield } from 'lucide-react';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
         title: 'Dashboard',
-        href: dashboard().url,
+        href: '/dashboard',
     },
 ];
 
 export default function Dashboard() {
+    const { auth } = usePage<SharedData>().props;
+
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Dashboard" />
-            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
-                <div className="grid auto-rows-min gap-4 md:grid-cols-3">
-                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                        <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
-                    </div>
-                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                        <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
-                    </div>
-                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                        <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
-                    </div>
+            <div className="flex h-full flex-1 flex-col items-center justify-center gap-6 p-8">
+                <div className="text-center">
+                    <h1 className="text-2xl font-bold tracking-tight">Welcome, {auth.user.name}</h1>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                        Manage your account settings below.
+                    </p>
                 </div>
-                <div className="relative min-h-[100vh] flex-1 overflow-hidden rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border">
-                    <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
+                <div className="flex flex-col gap-3 sm:flex-row">
+                    <Link
+                        href="/settings/profile"
+                        className="inline-flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors hover:bg-muted"
+                    >
+                        <Settings className="size-4" />
+                        Profile Settings
+                    </Link>
+                    <Link
+                        href="/admin"
+                        className="inline-flex items-center gap-2 rounded-lg bg-ballistic-indigo px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-ballistic-indigo/90"
+                    >
+                        <Shield className="size-4" />
+                        Admin Panel
+                    </Link>
                 </div>
             </div>
         </AppLayout>

--- a/apps/backend/resources/js/types/index.d.ts
+++ b/apps/backend/resources/js/types/index.d.ts
@@ -40,3 +40,72 @@ export interface User {
     updated_at: string;
     [key: string]: unknown; // This allows for additional properties...
 }
+
+// Admin-specific types
+export interface AdminUser extends User {
+    phone: string | null;
+    notes: string | null;
+    is_admin: boolean;
+    items_count: number;
+    projects_count: number;
+    tags_count: number;
+}
+
+export interface PaginationLink {
+    url: string | null;
+    label: string;
+    active: boolean;
+}
+
+export interface PaginatedResponse<T> {
+    data: T[];
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+    from: number | null;
+    to: number | null;
+    links: PaginationLink[];
+    path: string;
+}
+
+export interface AdminStats {
+    users: {
+        total: number;
+        admins: number;
+        verified: number;
+    };
+    content: {
+        active_todos: number;
+        active_lists: number;
+        total_items: number;
+        items_by_status: {
+            todo: number;
+            doing: number;
+            done: number;
+            wontdo: number;
+        };
+    };
+    growth: {
+        new_users_24h: number;
+        new_items_24h: number;
+        completed_items_24h: number;
+    };
+    queue: {
+        pending_jobs: number;
+        failed_jobs: number;
+        pending_notifications: number;
+    };
+}
+
+export interface CollaborationItem {
+    id: string;
+    title: string;
+    status: string;
+    project_id: string | null;
+    completed_at: string | null;
+    created_at: string;
+    project: { id: string; name: string; color: string } | null;
+    user?: { id: string; name: string; email: string };
+    assignee?: { id: string; name: string; email: string };
+}

--- a/apps/backend/routes/admin.php
+++ b/apps/backend/routes/admin.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Admin\Web\DashboardController;
+use App\Http\Controllers\Admin\Web\UsersController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('admin')
+    ->name('admin.')
+    ->middleware(['auth', 'verified', 'admin'])
+    ->group(function (): void {
+        // Health Pulse dashboard
+        Route::get('/', DashboardController::class)->name('dashboard');
+
+        // User management
+        Route::get('/users', [UsersController::class, 'index'])->name('users.index');
+        Route::get('/users/{user}', [UsersController::class, 'show'])->name('users.show');
+        Route::patch('/users/{user}', [UsersController::class, 'update'])->name('users.update');
+        Route::post('/users/{user}/hard-reset', [UsersController::class, 'hardReset'])->name('users.hard-reset');
+    });

--- a/apps/backend/routes/web.php
+++ b/apps/backend/routes/web.php
@@ -7,13 +7,15 @@ Route::get('/', function () {
     return Inertia::render('welcome');
 })->name('home');
 
-// Web dashboard is restricted to admin users only
-// Regular users should use the API and mobile/desktop apps
-Route::middleware(['auth', 'verified', 'admin'])->group(function () {
-    Route::get('dashboard', function () {
-        return Inertia::render('dashboard');
-    })->name('dashboard');
-});
+// Smart dashboard redirect: admins go to admin panel, others go to profile settings
+Route::get('dashboard', function () {
+    if (auth()->user()?->is_admin) {
+        return redirect()->route('admin.dashboard');
+    }
 
+    return redirect()->route('profile.edit');
+})->name('dashboard')->middleware(['auth', 'verified']);
+
+require __DIR__.'/admin.php';
 require __DIR__.'/settings.php';
 require __DIR__.'/auth.php';

--- a/apps/backend/tests/Feature/AdminWebTest.php
+++ b/apps/backend/tests/Feature/AdminWebTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Item;
+use App\Models\Notification;
+use App\Models\Project;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class AdminWebTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // =========================================================
+    // Access Control
+    // =========================================================
+
+    public function test_guest_is_redirected_from_admin_dashboard(): void
+    {
+        $this->get('/admin')->assertRedirect('/login');
+    }
+
+    public function test_non_admin_cannot_access_admin_dashboard(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($user)->get('/admin')->assertForbidden();
+    }
+
+    public function test_admin_can_access_admin_dashboard(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin)->get('/admin')->assertOk();
+    }
+
+    public function test_non_admin_cannot_access_admin_users_index(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->get('/admin/users')->assertForbidden();
+    }
+
+    public function test_admin_can_access_admin_users_index(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin)->get('/admin/users')->assertOk();
+    }
+
+    public function test_sanctum_token_cannot_access_web_admin_routes(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $token = $admin->createToken('test')->plainTextToken;
+
+        // Hit a web admin route with just the token header (no session)
+        $response = $this->withToken($token)->get('/admin');
+
+        // Web routes use 'auth' (session) middleware; token-only → redirect to login
+        $response->assertRedirect('/login');
+    }
+
+    // =========================================================
+    // Search and Pagination
+    // =========================================================
+
+    public function test_admin_can_search_users_by_email_fragment(): void
+    {
+        $admin = User::factory()->admin()->create();
+        User::factory()->create(['email' => 'specific.user@example.com', 'name' => 'Specific User']);
+        User::factory()->count(5)->create();
+
+        $response = $this->actingAs($admin)->get('/admin/users?search=specific.user');
+
+        $response->assertOk()
+            ->assertInertia(
+                fn ($page) => $page
+                    ->component('admin/users/index')
+                    ->has('users.data', 1)
+                    ->where('users.data.0.email', 'specific.user@example.com'),
+            );
+    }
+
+    public function test_admin_can_search_users_by_phone_fragment(): void
+    {
+        $admin = User::factory()->admin()->create();
+        User::factory()->create(['phone' => '+61400123456']);
+        User::factory()->count(5)->create();
+
+        $response = $this->actingAs($admin)->get('/admin/users?search=61400');
+
+        $response->assertOk()
+            ->assertInertia(
+                fn ($page) => $page
+                    ->component('admin/users/index')
+                    ->has('users.data', 1),
+            );
+    }
+
+    public function test_search_shorter_than_two_chars_returns_all_users(): void
+    {
+        $admin = User::factory()->admin()->create();
+        User::factory()->count(3)->create();
+
+        // Single char search should return all users (no filter)
+        $response = $this->actingAs($admin)->get('/admin/users?search=a');
+        $response->assertOk()
+            ->assertInertia(fn ($page) => $page->has('users.data', 4)); // 3 + admin
+    }
+
+    public function test_admin_can_filter_users_by_role(): void
+    {
+        $admin = User::factory()->admin()->create();
+        User::factory()->count(3)->create(['is_admin' => false]);
+
+        $response = $this->actingAs($admin)->get('/admin/users?role=admin');
+
+        $response->assertOk()
+            ->assertInertia(fn ($page) => $page->has('users.data', 1));
+    }
+
+    public function test_users_paginate_at_25_per_page(): void
+    {
+        $admin = User::factory()->admin()->create();
+        User::factory()->count(30)->create();
+
+        $response = $this->actingAs($admin)->get('/admin/users');
+
+        $response->assertOk()
+            ->assertInertia(
+                fn ($page) => $page
+                    ->component('admin/users/index')
+                    ->where('users.per_page', 25)
+                    ->where('users.total', 31),
+            );
+    }
+
+    // =========================================================
+    // User Detail / Collaboration History
+    // =========================================================
+
+    public function test_admin_can_view_user_collaboration_history(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+
+        $project = Project::factory()->create(['user_id' => $other->id]);
+        Item::factory()->create([
+            'user_id' => $other->id,
+            'assignee_id' => $user->id,
+            'project_id' => $project->id,
+            'title' => 'Assigned Task',
+        ]);
+
+        $project2 = Project::factory()->create(['user_id' => $user->id]);
+        Item::factory()->create([
+            'user_id' => $user->id,
+            'assignee_id' => $other->id,
+            'project_id' => $project2->id,
+            'title' => 'Delegated Task',
+        ]);
+
+        $response = $this->actingAs($admin)->get("/admin/users/{$user->id}");
+
+        $response->assertOk()
+            ->assertInertia(
+                fn ($page) => $page
+                    ->component('admin/users/show')
+                    ->has('assigned_items', 1)
+                    ->has('delegated_items', 1)
+                    ->where('assigned_items.0.title', 'Assigned Task')
+                    ->where('delegated_items.0.title', 'Delegated Task'),
+            );
+    }
+
+    // =========================================================
+    // Hard Reset
+    // =========================================================
+
+    public function test_admin_can_hard_reset_user_data(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create();
+
+        $project = Project::factory()->create(['user_id' => $user->id]);
+        Item::factory()->count(5)->create(['user_id' => $user->id, 'project_id' => $project->id]);
+        Tag::factory()->count(3)->create(['user_id' => $user->id]);
+        Notification::factory()->count(2)->create(['user_id' => $user->id, 'type' => 'task_assigned', 'title' => 'T', 'message' => 'M']);
+
+        $this->actingAs($admin)
+            ->post("/admin/users/{$user->id}/hard-reset")
+            ->assertRedirect();
+
+        $this->assertDatabaseCount('items', 0);
+        $this->assertDatabaseCount('projects', 0);
+        $this->assertDatabaseMissing('tags', ['user_id' => $user->id]);
+        $this->assertDatabaseMissing('notifications', ['user_id' => $user->id]);
+
+        // User account still exists
+        $this->assertDatabaseHas('users', ['id' => $user->id]);
+    }
+
+    public function test_admin_cannot_hard_reset_own_account(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin)
+            ->post("/admin/users/{$admin->id}/hard-reset")
+            ->assertRedirect()
+            ->assertSessionHasErrors('hard_reset');
+    }
+
+    // =========================================================
+    // Role Toggle
+    // =========================================================
+
+    public function test_admin_can_promote_user_to_admin(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($admin)
+            ->patch("/admin/users/{$user->id}", ['is_admin' => true])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('users', ['id' => $user->id, 'is_admin' => true]);
+    }
+
+    public function test_admin_cannot_demote_themselves(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin)
+            ->patch("/admin/users/{$admin->id}", ['is_admin' => false])
+            ->assertRedirect()
+            ->assertSessionHasErrors('is_admin');
+    }
+
+    // =========================================================
+    // Dashboard stats
+    // =========================================================
+
+    public function test_health_pulse_returns_correct_stats(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['user_id' => $user->id]);
+        Item::factory()->count(3)->todo()->create(['user_id' => $user->id, 'project_id' => $project->id]);
+        Item::factory()->count(2)->done()->create(['user_id' => $user->id, 'project_id' => $project->id]);
+
+        $response = $this->actingAs($admin)->get('/admin');
+
+        $response->assertOk()
+            ->assertInertia(
+                fn ($page) => $page
+                    ->component('admin/dashboard')
+                    ->where('stats.users.total', 2)
+                    ->where('stats.content.active_todos', 3)
+                    ->where('stats.content.items_by_status.todo', 3)
+                    ->where('stats.content.items_by_status.done', 2),
+            );
+    }
+}

--- a/apps/backend/tests/Feature/AuditLogTest.php
+++ b/apps/backend/tests/Feature/AuditLogTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\Item;
+use App\Models\Project;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+final class AuditLogTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // -----------------------------------------------------------------------
+    // Creation via HTTP actions
+    // -----------------------------------------------------------------------
+
+    public function test_hard_reset_creates_audit_log_entry(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create();
+
+        Project::factory()->create(['user_id' => $user->id]);
+        Item::factory()->count(3)->create(['user_id' => $user->id]);
+        Tag::factory()->count(2)->create(['user_id' => $user->id]);
+
+        $this->actingAs($admin)
+            ->post("/admin/users/{$user->id}/hard-reset")
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('audit_logs', [
+            'admin_id' => (string) $admin->getKey(),
+            'action' => 'user.hard_reset',
+            'subject_type' => 'user',
+            'subject_id' => (string) $user->getKey(),
+        ]);
+
+        $log = AuditLog::where('action', 'user.hard_reset')->first();
+        $this->assertNotNull($log);
+        $this->assertArrayHasKey('items_count', $log->old_values);
+        $this->assertArrayHasKey('projects_count', $log->old_values);
+        $this->assertNull($log->new_values);
+    }
+
+    public function test_role_change_creates_audit_log_entry(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($admin)
+            ->patch("/admin/users/{$user->id}", ['is_admin' => true])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('audit_logs', [
+            'admin_id' => (string) $admin->getKey(),
+            'action' => 'user.role_changed',
+            'subject_type' => 'user',
+            'subject_id' => (string) $user->getKey(),
+        ]);
+
+        $log = AuditLog::where('action', 'user.role_changed')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(['is_admin' => false], $log->old_values);
+        $this->assertEquals(['is_admin' => true], $log->new_values);
+    }
+
+    public function test_profile_update_creates_audit_log_entry(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create(['name' => 'Old Name']);
+
+        $this->actingAs($admin)
+            ->patch("/admin/users/{$user->id}", ['name' => 'New Name'])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('audit_logs', [
+            'admin_id' => (string) $admin->getKey(),
+            'action' => 'user.profile_updated',
+            'subject_type' => 'user',
+            'subject_id' => (string) $user->getKey(),
+        ]);
+
+        $log = AuditLog::where('action', 'user.profile_updated')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(['name' => 'Old Name'], $log->old_values);
+        $this->assertEquals(['name' => 'New Name'], $log->new_values);
+    }
+
+    public function test_multiple_audit_logs_are_recorded_for_multiple_actions(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($admin)->patch("/admin/users/{$user->id}", ['is_admin' => true]);
+        $this->actingAs($admin)->patch("/admin/users/{$user->id}", ['name' => 'Updated']);
+
+        $this->assertDatabaseCount('audit_logs', 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Timestamp correctness
+    // -----------------------------------------------------------------------
+
+    public function test_created_at_is_populated_automatically(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create();
+
+        $before = Carbon::now()->subSecond();
+
+        $this->actingAs($admin)
+            ->post("/admin/users/{$user->id}/hard-reset")
+            ->assertRedirect();
+
+        $after = Carbon::now()->addSecond();
+
+        $log = AuditLog::where('action', 'user.hard_reset')->first();
+        $this->assertNotNull($log->created_at);
+        $this->assertInstanceOf(Carbon::class, $log->created_at);
+        $this->assertTrue($log->created_at->between($before, $after));
+    }
+
+    public function test_created_at_is_in_utc(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create();
+
+        $this->actingAs($admin)
+            ->post("/admin/users/{$user->id}/hard-reset")
+            ->assertRedirect();
+
+        $log = AuditLog::where('action', 'user.hard_reset')->first();
+        $this->assertEquals('UTC', $log->created_at->timezone->getName());
+    }
+
+    public function test_audit_log_has_no_updated_at(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create();
+
+        $this->actingAs($admin)
+            ->post("/admin/users/{$user->id}/hard-reset")
+            ->assertRedirect();
+
+        $log = AuditLog::where('action', 'user.hard_reset')->first();
+
+        // The model exposes no updated_at and the column does not exist
+        $this->assertArrayNotHasKey('updated_at', $log->getAttributes());
+        $this->assertNull(AuditLog::UPDATED_AT);
+    }
+
+    // -----------------------------------------------------------------------
+    // Single-write guarantee (IP / UA recorded in the INSERT, not a follow-up UPDATE)
+    // -----------------------------------------------------------------------
+
+    public function test_ip_address_recorded_on_hard_reset(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create();
+
+        $this->actingAs($admin)
+            ->post("/admin/users/{$user->id}/hard-reset", [], ['REMOTE_ADDR' => '1.2.3.4'])
+            ->assertRedirect();
+
+        $log = AuditLog::where('action', 'user.hard_reset')->first();
+        $this->assertEquals('1.2.3.4', $log->ip_address);
+    }
+
+    public function test_ip_address_recorded_on_role_change(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($admin)
+            ->patch("/admin/users/{$user->id}", ['is_admin' => true], ['REMOTE_ADDR' => '9.8.7.6'])
+            ->assertRedirect();
+
+        $log = AuditLog::where('action', 'user.role_changed')->first();
+        $this->assertEquals('9.8.7.6', $log->ip_address);
+    }
+
+    public function test_ip_address_recorded_on_profile_update(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create(['name' => 'Old']);
+
+        $this->actingAs($admin)
+            ->patch("/admin/users/{$user->id}", ['name' => 'New'], ['REMOTE_ADDR' => '10.0.0.1'])
+            ->assertRedirect();
+
+        $log = AuditLog::where('action', 'user.profile_updated')->first();
+        $this->assertEquals('10.0.0.1', $log->ip_address);
+    }
+
+    // -----------------------------------------------------------------------
+    // Factory usage
+    // -----------------------------------------------------------------------
+
+    public function test_factory_creates_valid_audit_log(): void
+    {
+        $log = AuditLog::factory()->create();
+
+        $this->assertNotNull($log->id);
+        $this->assertNotNull($log->admin_id);
+        $this->assertNotNull($log->action);
+        $this->assertNotNull($log->created_at);
+        $this->assertInstanceOf(Carbon::class, $log->created_at);
+    }
+
+    public function test_factory_hard_reset_state(): void
+    {
+        $log = AuditLog::factory()->hardReset()->create();
+
+        $this->assertEquals('user.hard_reset', $log->action);
+        $this->assertArrayHasKey('items_count', $log->old_values);
+    }
+
+    public function test_factory_role_changed_state(): void
+    {
+        $log = AuditLog::factory()->roleChanged()->create();
+
+        $this->assertEquals('user.role_changed', $log->action);
+        $this->assertEquals(['is_admin' => false], $log->old_values);
+        $this->assertEquals(['is_admin' => true], $log->new_values);
+    }
+
+    // -----------------------------------------------------------------------
+    // Relationship
+    // -----------------------------------------------------------------------
+
+    public function test_admin_relationship_loads_correctly(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $log = AuditLog::factory()->create(['admin_id' => (string) $admin->getKey()]);
+
+        $this->assertEquals((string) $admin->getKey(), (string) $log->admin->getKey());
+        $this->assertEquals($admin->name, $log->admin->name);
+    }
+}

--- a/apps/backend/tests/Feature/DashboardTest.php
+++ b/apps/backend/tests/Feature/DashboardTest.php
@@ -17,21 +17,21 @@ class DashboardTest extends TestCase
         $this->get(route('dashboard'))->assertRedirect(route('login'));
     }
 
-    public function test_non_admin_users_are_forbidden_from_dashboard(): void
+    public function test_non_admin_users_are_redirected_to_profile(): void
     {
         $user = User::factory()->create(['is_admin' => false]);
 
         $this->actingAs($user)
             ->get(route('dashboard'))
-            ->assertStatus(403);
+            ->assertRedirect(route('profile.edit'));
     }
 
-    public function test_admin_users_can_visit_the_dashboard(): void
+    public function test_admin_users_are_redirected_to_admin_dashboard(): void
     {
         $admin = User::factory()->admin()->create();
 
         $this->actingAs($admin)
             ->get(route('dashboard'))
-            ->assertOk();
+            ->assertRedirect(route('admin.dashboard'));
     }
 }

--- a/apps/backend/tests/TestCase.php
+++ b/apps/backend/tests/TestCase.php
@@ -19,5 +19,8 @@ abstract class TestCase extends BaseTestCase
             \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
         ]);
+
+        // Fake Vite manifest so Inertia page renders don't fail in tests
+        $this->withoutVite();
     }
 }


### PR DESCRIPTION
## Summary

- Admin dashboard (secure middleware, user management, collaboration history, health pulse stats)
- AuditLog model/service tracking admin actions (hard resets, role changes, profile updates)
- PHP type safety: `declare(strict_types=1)` + `final` added across all controllers, middleware, seeders, form requests; typed closure parameters throughout
- Fixed `resolveRouteBinding` LSP compatibility and eager-load closure type mismatch (`HasMany` vs `Builder`)

## Test plan

- [x] All 281 backend tests passing (`./runtests.sh`)
- [x] Frontend ESLint passing (`npm run lint`)
- [x] CI/CD checks on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)