### PR TITLE
Fix push notifications end-to-end

### DIFF
--- a/apps/backend/app/Services/WebPushService.php
+++ b/apps/backend/app/Services/WebPushService.php
@@ -66,10 +66,17 @@ final class WebPushService implements WebPushServiceInterface
     public function sendToSubscription(PushSubscription $subscription, array $payload): bool
     {
         if (! $this->isConfigured()) {
-            Log::warning('WebPush: VAPID keys not configured, skipping push notification');
+            Log::channel('webpush')->warning('VAPID keys not configured — push skipped', [
+                'subscription_id' => $subscription->id,
+            ]);
 
             return false;
         }
+
+        Log::channel('webpush')->debug('Sending to single subscription', [
+            'subscription_id' => $subscription->id,
+            'title' => $payload['title'] ?? '(no title)',
+        ]);
 
         try {
             $webPushSubscription = Subscription::create($subscription->toWebPushFormat());
@@ -82,16 +89,17 @@ final class WebPushService implements WebPushServiceInterface
 
             foreach ($results as $report) {
                 if ($report->isSuccess()) {
+                    Log::channel('webpush')->info('Successfully delivered', [
+                        'subscription_id' => $subscription->id,
+                    ]);
                     $subscription->markAsUsed();
 
                     return true;
                 }
 
-                $reason = $report->getReason();
-
-                // Subscription expired or invalid - remove it
+                // Subscription expired or invalid — remove it
                 if ($report->isSubscriptionExpired()) {
-                    Log::info('WebPush: Removing expired subscription', [
+                    Log::channel('webpush')->info('Subscription expired, removing', [
                         'subscription_id' => $subscription->id,
                         'endpoint' => $subscription->endpoint,
                     ]);
@@ -100,15 +108,15 @@ final class WebPushService implements WebPushServiceInterface
                     return false;
                 }
 
-                Log::warning('WebPush: Failed to send notification', [
+                Log::channel('webpush')->warning('Delivery failed', [
                     'subscription_id' => $subscription->id,
-                    'reason' => $reason,
+                    'reason' => $report->getReason(),
                 ]);
             }
 
             return false;
         } catch (\Throwable $e) {
-            Log::error('WebPush: Exception while sending notification', [
+            Log::channel('webpush')->error('Exception while sending', [
                 'subscription_id' => $subscription->id,
                 'error' => $e->getMessage(),
             ]);
@@ -126,16 +134,38 @@ final class WebPushService implements WebPushServiceInterface
     public function sendToUser(User $user, array $payload): int
     {
         if (! $this->isConfigured()) {
+            Log::channel('webpush')->warning('VAPID keys not configured — push skipped', [
+                'user_id' => $user->id,
+            ]);
+
             return 0;
         }
 
         $subscriptions = $user->pushSubscriptions()->get();
 
         if ($subscriptions->isEmpty()) {
+            Log::channel('webpush')->debug('No push subscriptions for user', [
+                'user_id' => $user->id,
+            ]);
+
             return 0;
         }
 
-        return $this->sendToSubscriptions($subscriptions, $payload);
+        Log::channel('webpush')->info('Dispatching push to user', [
+            'user_id' => $user->id,
+            'subscription_count' => $subscriptions->count(),
+            'title' => $payload['title'] ?? '(no title)',
+        ]);
+
+        $delivered = $this->sendToSubscriptions($subscriptions, $payload);
+
+        Log::channel('webpush')->info('Push delivery complete for user', [
+            'user_id' => $user->id,
+            'delivered' => $delivered,
+            'of' => $subscriptions->count(),
+        ]);
+
+        return $delivered;
     }
 
     /**
@@ -147,38 +177,67 @@ final class WebPushService implements WebPushServiceInterface
      */
     public function sendToSubscriptions(Collection $subscriptions, array $payload): int
     {
-        if (! $this->isConfigured() || $subscriptions->isEmpty()) {
+        if (! $this->isConfigured()) {
+            Log::channel('webpush')->warning('VAPID keys not configured — batch push skipped');
+
+            return 0;
+        }
+
+        if ($subscriptions->isEmpty()) {
             return 0;
         }
 
         $webPush = $this->getWebPush();
         $payloadJson = json_encode($payload, JSON_THROW_ON_ERROR);
 
-        // Queue all notifications
-        $indexedSubscriptions = $subscriptions->values();
-        foreach ($indexedSubscriptions as $subscription) {
+        // Only append to $queuedSubscriptions when queueNotification() succeeds.
+        // This keeps the array positionally aligned with what flush() will yield —
+        // if an entry fails to queue (exception) it is simply absent from both arrays,
+        // so there is no off-by-one when matching reports back to subscriptions.
+        $queuedSubscriptions = [];
+
+        foreach ($subscriptions as $subscription) {
             try {
                 $webPushSubscription = Subscription::create($subscription->toWebPushFormat());
                 $webPush->queueNotification($webPushSubscription, $payloadJson);
+                $queuedSubscriptions[] = $subscription;
             } catch (\Throwable $e) {
-                Log::warning('WebPush: Failed to queue notification', [
+                Log::channel('webpush')->warning('Failed to queue subscription — skipping', [
                     'subscription_id' => $subscription->id,
                     'error' => $e->getMessage(),
                 ]);
             }
         }
 
-        // Flush and process results - collect IDs for batch operations
+        if (empty($queuedSubscriptions)) {
+            Log::channel('webpush')->warning('No subscriptions could be queued for batch push');
+
+            return 0;
+        }
+
+        Log::channel('webpush')->debug('Flushing queued notifications', [
+            'queued' => count($queuedSubscriptions),
+        ]);
+
+        // Flush and match each report back to its subscription by position.
+        // $queuedSubscriptions[N] corresponds exactly to the Nth report from flush()
+        // because both reflect only the notifications that were successfully handed
+        // to the library.
         $successfulIds = [];
         $expiredIds = [];
-        $subscriptionIndex = 0;
+        $reportIndex = 0;
 
         foreach ($webPush->flush() as $report) {
-            /** @var PushSubscription|null $subscription */
-            $subscription = $indexedSubscriptions->get($subscriptionIndex);
-            $subscriptionIndex++;
+            $subscription = $queuedSubscriptions[$reportIndex] ?? null;
+            $reportIndex++;
 
             if ($subscription === null) {
+                // flush() yielded more reports than we queued — should never happen.
+                Log::channel('webpush')->error('Received more flush reports than queued subscriptions', [
+                    'report_index' => $reportIndex - 1,
+                    'queued_count' => count($queuedSubscriptions),
+                ]);
+
                 continue;
             }
 
@@ -189,7 +248,7 @@ final class WebPushService implements WebPushServiceInterface
             }
 
             if ($report->isSubscriptionExpired()) {
-                Log::info('WebPush: Removing expired subscription', [
+                Log::channel('webpush')->info('Subscription expired, queued for removal', [
                     'subscription_id' => $subscription->id,
                 ]);
                 $expiredIds[] = $subscription->id;
@@ -197,9 +256,17 @@ final class WebPushService implements WebPushServiceInterface
                 continue;
             }
 
-            Log::warning('WebPush: Delivery failed', [
+            Log::channel('webpush')->warning('Delivery failed', [
                 'subscription_id' => $subscription->id,
                 'reason' => $report->getReason(),
+            ]);
+        }
+
+        // Sanity-check: flush() should yield exactly one report per queued notification.
+        if ($reportIndex < count($queuedSubscriptions)) {
+            Log::channel('webpush')->warning('Fewer flush reports than queued subscriptions — some deliveries unaccounted for', [
+                'expected' => count($queuedSubscriptions),
+                'received' => $reportIndex,
             ]);
         }
 
@@ -214,6 +281,13 @@ final class WebPushService implements WebPushServiceInterface
                 PushSubscription::whereIn('id', $expiredIds)->delete();
             }
         });
+
+        Log::channel('webpush')->info('Batch delivery complete', [
+            'queued' => count($queuedSubscriptions),
+            'delivered' => count($successfulIds),
+            'expired_removed' => count($expiredIds),
+            'failed' => count($queuedSubscriptions) - count($successfulIds) - count($expiredIds),
+        ]);
 
         return count($successfulIds);
     }

--- a/apps/backend/config/logging.php
+++ b/apps/backend/config/logging.php
@@ -127,6 +127,14 @@ return [
             'path' => storage_path('logs/laravel.log'),
         ],
 
+        'webpush' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/webpush.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'days' => 14,
+            'replace_placeholders' => true,
+        ],
+
     ],
 
 ];

--- a/apps/frontend/.gitignore
+++ b/apps/frontend/.gitignore
@@ -20,6 +20,10 @@
 # production
 /build
 
+# serwist generated service worker (compiled by next build, not source)
+/public/sw.js
+/public/sw.js.map
+
 # misc
 .DS_Store
 *.pem

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -4,6 +4,7 @@ import withSerwistInit from "@serwist/next";
 const withSerwist = withSerwistInit({
   swSrc: "src/app/sw.ts",
   swDest: "public/sw.js",
+  disable: process.env.NODE_ENV !== "production",
 });
 
 const nextConfig: NextConfig = {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "next build",
     "start": "next start -p $PORT",
     "test": "jest",
     "lint": "next lint --max-warnings=0",

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { Nunito } from "next/font/google";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { ServiceWorkerRegistration } from "@/components/ServiceWorkerRegistration";
 
 const nunito = Nunito({
   subsets: ["latin"],
@@ -37,6 +38,7 @@ export default function RootLayout({
       <body
         className={`min-h-dvh bg-[var(--page-bg)] text-[var(--text)] ${nunito.className}`}
       >
+        <ServiceWorkerRegistration />
         <AuthProvider>
           <div className="mx-auto w-full max-w-screen-sm p-4">{children}</div>
         </AuthProvider>

--- a/apps/frontend/src/components/ServiceWorkerRegistration.tsx
+++ b/apps/frontend/src/components/ServiceWorkerRegistration.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { Serwist } from "@serwist/window";
+
+/**
+ * Registers the compiled service worker (/sw.js) on mount.
+ * Must be a client component so it can access navigator.serviceWorker.
+ * Without this, usePushNotifications hangs at navigator.serviceWorker.ready.
+ */
+export function ServiceWorkerRegistration() {
+  useEffect(() => {
+    // Serwist doesn't support Turbopack, so sw.js is only compiled during
+    // `next build` (webpack). Skip registration outside production to avoid
+    // a 404-caused installation error in dev/test.
+    if (
+      typeof window !== "undefined" &&
+      "serviceWorker" in navigator &&
+      process.env.NODE_ENV === "production"
+    ) {
+      const serwist = new Serwist("/sw.js", { scope: "/" });
+      serwist.register();
+    }
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- **Service worker never registered**: `navigator.serviceWorker.ready` hung indefinitely because no SW was ever registered in the browser — the entire push subscription flow was unreachable. Added `ServiceWorkerRegistration` client component (uses `@serwist/window`) mounted in `layout.tsx`.
- **Serwist + Turbopack incompatibility**: `next build --turbopack` skips webpack plugins entirely, so `public/sw.js` was never compiled — push notifications were broken in production too. Removed `--turbopack` from the build script so Serwist's webpack plugin runs.
- **Dev-mode guard**: Added `disable: process.env.NODE_ENV !== "production"` in `next.config.ts` and matching guard in the component to prevent 404-caused SW installation errors during `next dev`.
- **WebPushService observability**: Added dedicated `webpush` daily log channel, eliminated silent `return 0` on unconfigured VAPID, fixed off-by-one index bug in `sendToSubscriptions()` (flush reports were misattributed to wrong subscriptions after any queueing failure).

## Test plan

- [ ] `./runtests.sh` — 263 passed, 2 pre-existing audit-log failures (missing Vite page)
- [ ] `npm run lint` — no warnings or errors
- [ ] `npm run build` — Serwist logs `✓ Bundling the service worker script` and `public/sw.js` is generated
- [ ] In production, opening the app registers the SW; the Settings push toggle reaches `prompt` state and allows subscribing

🤖 Generated with [Claude Code](https://claude.com/claude-code)