### PR TITLE
Predictive velocity & burnout forecaster (v0.16.0)

### DIFF
--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-02-27
+
+### Added
+
+#### Predictive Velocity & Burnout Forecaster
+
+- **`effort_score` column on items**: Fibonacci-scale effort points (1, 2, 3, 5, 8) with default of 1, enabling velocity tracking per task
+- **Composite index** `(user_id, status, completed_at)` for efficient velocity query performance
+- **`VelocityForecastingService`**: Core math engine implementing EMA-based velocity calculation, exponentially-weighted standard deviation, Abramowitz & Stegun normal CDF approximation, and burnout risk detection at the 90th percentile capacity threshold
+- **`GET /api/velocity/forecast`**: New endpoint returning velocity, capacity, demand, burnout risk flag, probability of success, and 12-week effort history — gated behind `velocity` feature flag
+- **`VelocityForecastResource`**: JSON resource with explicit rounding for display values
+- **`EnsureVelocityEnabled` middleware**: Feature flag gate following the `EnsureAiAssistantEnabled` pattern (404 when disabled)
+- **`velocity` feature flag**: Added to `UserController` allowlist and validation rules
+
+### Tests
+
+- **Unit**: `VelocityForecastingServiceTest` — EMA convergence, CDF accuracy (z=0 → 0.5, z=1.645 → 0.95), probability edge cases (zero std dev, demand > capacity), gap filling
+- **Feature**: `VelocityForecastTest` — authenticated/unauthenticated/flag-disabled access, burnout detection with 25-point demand vs ~10 velocity, no-burnout with low demand, new user empty state
+- **Feature**: `ItemEffortScoreTest` — default value, CRUD persistence, Fibonacci validation (rejects 0, 4, 9, -1), API response inclusion
+
 ## [0.15.1] - 2026-02-21
 
 ### Changed

--- a/apps/backend/app/Http/Controllers/Api/UserController.php
+++ b/apps/backend/app/Http/Controllers/Api/UserController.php
@@ -52,6 +52,7 @@ final class UserController extends Controller
             'feature_flags.dates' => ['sometimes', 'boolean'],
             'feature_flags.delegation' => ['sometimes', 'boolean'],
             'feature_flags.ai_assistant' => ['sometimes', 'boolean'],
+            'feature_flags.velocity' => ['sometimes', 'boolean'],
             'password' => ['sometimes', 'required', 'confirmed', Password::defaults()],
         ]);
 
@@ -60,7 +61,7 @@ final class UserController extends Controller
         }
 
         if (array_key_exists('feature_flags', $validated) && is_array($validated['feature_flags'])) {
-            $allowedFlagKeys = ['dates', 'delegation', 'ai_assistant'];
+            $allowedFlagKeys = ['dates', 'delegation', 'ai_assistant', 'velocity'];
             $incomingFlags = array_intersect_key($validated['feature_flags'], array_flip($allowedFlagKeys));
 
             $validated['feature_flags'] = array_merge(

--- a/apps/backend/app/Http/Controllers/ItemController.php
+++ b/apps/backend/app/Http/Controllers/ItemController.php
@@ -164,6 +164,7 @@ final class ItemController extends Controller
                 ...$validated,
                 'user_id' => Auth::id(),
                 'position' => $validated['position'] ?? 0,
+                'effort_score' => $validated['effort_score'] ?? 1,
             ]);
 
             if (! empty($tagIds)) {

--- a/apps/backend/app/Http/Controllers/VelocityController.php
+++ b/apps/backend/app/Http/Controllers/VelocityController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\VelocityForecastResource;
+use App\Models\User;
+use App\Services\VelocityForecastingService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class VelocityController extends Controller
+{
+    /**
+     * Return a velocity forecast for the authenticated user.
+     */
+    public function forecast(Request $request, VelocityForecastingService $service): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $forecast = $service->forecast((string) $user->id);
+
+        return (new VelocityForecastResource($forecast))
+            ->response()
+            ->setStatusCode(200);
+    }
+}

--- a/apps/backend/app/Http/Middleware/EnsureVelocityEnabled.php
+++ b/apps/backend/app/Http/Middleware/EnsureVelocityEnabled.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class EnsureVelocityEnabled
+{
+    /**
+     * Handle an incoming request.
+     *
+     * Ensures the authenticated user has enabled the velocity feature flag.
+     * Returns 404 if the feature is not enabled (to not reveal the endpoint exists).
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            abort(401);
+        }
+
+        $flags = $user->feature_flags ?? [];
+        $velocityEnabled = $flags['velocity'] ?? false;
+
+        if (! $velocityEnabled) {
+            abort(404);
+        }
+
+        return $next($request);
+    }
+}

--- a/apps/backend/app/Http/Requests/StoreItemRequest.php
+++ b/apps/backend/app/Http/Requests/StoreItemRequest.php
@@ -37,6 +37,7 @@ final class StoreItemRequest extends FormRequest
                 }),
             ],
             'position' => ['integer', 'min:0'],
+            'effort_score' => ['sometimes', 'integer', Rule::in([1, 2, 3, 5, 8])],
             'scheduled_date' => ['nullable', 'date'],
             'due_date' => ['nullable', 'date', 'after_or_equal:scheduled_date'],
             'recurrence_rule' => ['nullable', 'string', 'max:255'],

--- a/apps/backend/app/Http/Requests/UpdateItemRequest.php
+++ b/apps/backend/app/Http/Requests/UpdateItemRequest.php
@@ -38,6 +38,7 @@ final class UpdateItemRequest extends FormRequest
                 }),
             ],
             'position' => ['sometimes', 'integer', 'min:0'],
+            'effort_score' => ['sometimes', 'integer', Rule::in([1, 2, 3, 5, 8])],
             'scheduled_date' => ['nullable', 'date'],
             'due_date' => ['nullable', 'date', 'after_or_equal:scheduled_date'],
             'recurrence_rule' => ['nullable', 'string', 'max:255'],

--- a/apps/backend/app/Http/Resources/ItemResource.php
+++ b/apps/backend/app/Http/Resources/ItemResource.php
@@ -27,6 +27,7 @@ final class ItemResource extends JsonResource
             'assignee_notes' => $this->assignee_notes,
             'status' => $this->status,
             'position' => $this->position,
+            'effort_score' => $this->effort_score,
             'scheduled_date' => $this->scheduled_date?->toDateString(),
             'due_date' => $this->due_date?->toDateString(),
             'completed_at' => $this->completed_at?->toIso8601String(),

--- a/apps/backend/app/Http/Resources/VelocityForecastResource.php
+++ b/apps/backend/app/Http/Resources/VelocityForecastResource.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class VelocityForecastResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    public function toArray(Request $request): array
+    {
+        /** @var array<string, mixed> $data */
+        $data = $this->resource;
+
+        return [
+            'velocity' => round((float) $data['velocity'], 2),
+            'std_dev' => round((float) $data['std_dev'], 2),
+            'capacity' => round((float) $data['capacity'], 2),
+            'demand' => (int) $data['demand'],
+            'demand_task_count' => (int) $data['demand_task_count'],
+            'burnout_risk' => (bool) $data['burnout_risk'],
+            'probability_of_success' => $data['probability_of_success'] !== null
+                ? round((float) $data['probability_of_success'], 4)
+                : null,
+            'data_points' => (int) $data['data_points'],
+            'weekly_totals' => $data['weekly_totals'],
+        ];
+    }
+}

--- a/apps/backend/app/Models/Item.php
+++ b/apps/backend/app/Models/Item.php
@@ -31,6 +31,7 @@ final class Item extends Model
         'assignee_notes',
         'status',
         'position',
+        'effort_score',
         'scheduled_date',
         'due_date',
         'completed_at',
@@ -41,6 +42,7 @@ final class Item extends Model
 
     protected $casts = [
         'position' => 'integer',
+        'effort_score' => 'integer',
         'scheduled_date' => 'date',
         'due_date' => 'date',
         'completed_at' => 'datetime',
@@ -67,6 +69,7 @@ final class Item extends Model
             if (empty($model->id)) {
                 $model->id = Str::uuid();
             }
+            $model->effort_score ??= 1;
         });
     }
 

--- a/apps/backend/app/Services/VelocityForecastingService.php
+++ b/apps/backend/app/Services/VelocityForecastingService.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+
+final class VelocityForecastingService
+{
+    private const float ALPHA = 0.3;
+
+    private const int LOOKBACK_WEEKS = 12;
+
+    private const float Z_90 = 1.645;
+
+    /**
+     * SQL expression that truncates completed_at to the Monday of its week.
+     * Used as the canonical GROUP BY key — avoids driver-specific week numbering.
+     */
+    private function weekStartExpression(): string
+    {
+        return match (DB::getDriverName()) {
+            'pgsql' => "DATE_TRUNC('week', completed_at)::date",
+            'sqlite' => "date(completed_at, 'weekday 0', '-6 days')",
+            default => 'DATE(completed_at - INTERVAL (WEEKDAY(completed_at)) DAY)',
+        };
+    }
+
+    /**
+     * Get weekly effort totals for a user over the lookback period.
+     * Returns at most $weeks rows — all aggregation happens in the database.
+     *
+     * @return array<string, int> Keyed by Monday date (Y-m-d)
+     */
+    public function getWeeklyEffortTotals(string $userId, int $weeks = self::LOOKBACK_WEEKS): array
+    {
+        $lookbackDate = CarbonImmutable::now()->subWeeks($weeks)->startOfWeek();
+        $expr = $this->weekStartExpression();
+
+        $rows = DB::table('items')
+            ->selectRaw("{$expr} AS week_start")
+            ->selectRaw('COALESCE(SUM(effort_score), 0) AS total_effort')
+            ->where('user_id', $userId)
+            ->where('status', 'done')
+            ->whereNotNull('completed_at')
+            ->where('completed_at', '>=', $lookbackDate)
+            ->whereNull('deleted_at')
+            ->groupByRaw($expr)
+            ->orderByRaw($expr)
+            ->get();
+
+        $totals = [];
+        foreach ($rows as $row) {
+            $totals[$row->week_start] = (int) $row->total_effort;
+        }
+
+        return $totals;
+    }
+
+    /**
+     * Fill in zero-effort entries for weeks with no completions.
+     *
+     * @param  array<string, int>  $weeklyTotals  Keyed by Monday date (Y-m-d)
+     * @return array<int, array{week_label: string, total_effort: int}>
+     */
+    public function fillWeekGaps(array $weeklyTotals, int $weeks = self::LOOKBACK_WEEKS): array
+    {
+        $now = CarbonImmutable::now();
+        $filled = [];
+
+        for ($i = $weeks - 1; $i >= 0; $i--) {
+            $monday = $now->subWeeks($i)->startOfWeek();
+            $key = $monday->format('Y-m-d');
+            $weekLabel = $monday->format('o').'-W'.str_pad((string) $monday->isoWeek(), 2, '0', STR_PAD_LEFT);
+
+            $filled[] = [
+                'week_label' => $weekLabel,
+                'total_effort' => $weeklyTotals[$key] ?? 0,
+            ];
+        }
+
+        return $filled;
+    }
+
+    /**
+     * Calculate EMA and exponentially-weighted standard deviation.
+     *
+     * @param  array<int, int>  $efforts  Chronological weekly effort values
+     * @return array{ema: float, std_dev: float, data_points: int}
+     */
+    public function calculateEma(array $efforts, float $alpha = self::ALPHA): array
+    {
+        if (empty($efforts)) {
+            return ['ema' => 0.0, 'std_dev' => 0.0, 'data_points' => 0];
+        }
+
+        $ema = (float) $efforts[0];
+        $variance = 0.0;
+        $count = count($efforts);
+
+        for ($t = 1; $t < $count; $t++) {
+            $x = (float) $efforts[$t];
+            $diff = $x - $ema;
+            $variance = (1.0 - $alpha) * ($variance + $alpha * $diff * $diff);
+            $ema = $alpha * $x + (1.0 - $alpha) * $ema;
+        }
+
+        return [
+            'ema' => $ema,
+            'std_dev' => sqrt($variance),
+            'data_points' => $count,
+        ];
+    }
+
+    /**
+     * Get upcoming demand (effort sum + task count) for the next N days.
+     *
+     * @return array{effort: int, task_count: int}
+     */
+    public function getUpcomingDemand(string $userId, int $days = 7): array
+    {
+        $today = CarbonImmutable::now()->toDateString();
+        $endDate = CarbonImmutable::now()->addDays($days)->toDateString();
+
+        $result = DB::table('items')
+            ->selectRaw('COALESCE(SUM(effort_score), 0) AS total_effort')
+            ->selectRaw('COUNT(*) AS task_count')
+            ->where('user_id', $userId)
+            ->whereNotIn('status', ['done', 'wontdo'])
+            ->whereNotNull('due_date')
+            ->whereBetween('due_date', [$today, $endDate])
+            ->whereNull('deleted_at')
+            ->first();
+
+        return [
+            'effort' => (int) ($result->total_effort ?? 0),
+            'task_count' => (int) ($result->task_count ?? 0),
+        ];
+    }
+
+    /**
+     * Abramowitz & Stegun approximation of the standard normal CDF.
+     * Error < 7.5e-8.
+     */
+    public function normalCdf(float $x): float
+    {
+        if ($x < -8.0) {
+            return 0.0;
+        }
+        if ($x > 8.0) {
+            return 1.0;
+        }
+
+        $negative = $x < 0.0;
+        $x = abs($x);
+
+        $k = 1.0 / (1.0 + 0.2316419 * $x);
+        $k2 = $k * $k;
+        $k3 = $k2 * $k;
+        $k4 = $k3 * $k;
+        $k5 = $k4 * $k;
+
+        $pdf = exp(-0.5 * $x * $x) / sqrt(2.0 * M_PI);
+        $cdf = 1.0 - $pdf * (
+            0.319381530 * $k
+            - 0.356563782 * $k2
+            + 1.781477937 * $k3
+            - 1.821255978 * $k4
+            + 1.330274429 * $k5
+        );
+
+        return $negative ? 1.0 - $cdf : $cdf;
+    }
+
+    /**
+     * Calculate probability of completing upcoming demand given EMA and std dev.
+     */
+    public function calculateProbabilityOfSuccess(float $ema, float $stdDev, float $demand): float
+    {
+        if ($stdDev <= 0.0) {
+            return $demand <= $ema ? 1.0 : 0.0;
+        }
+
+        $zScore = ($ema - $demand) / $stdDev;
+
+        return $this->normalCdf($zScore);
+    }
+
+    /**
+     * Generate a full velocity forecast for a user.
+     *
+     * @return array{
+     *     velocity: float,
+     *     std_dev: float,
+     *     capacity: float,
+     *     demand: int,
+     *     demand_task_count: int,
+     *     burnout_risk: bool,
+     *     probability_of_success: float|null,
+     *     data_points: int,
+     *     weekly_totals: array<int, array{week_label: string, total_effort: int}>
+     * }
+     */
+    public function forecast(string $userId): array
+    {
+        $weeklyTotals = $this->getWeeklyEffortTotals($userId);
+        $filledTotals = $this->fillWeekGaps($weeklyTotals);
+        $hasHistory = $weeklyTotals !== [];
+
+        $efforts = array_map(fn (array $entry): int => $entry['total_effort'], $filledTotals);
+        $emaResult = $this->calculateEma($efforts);
+
+        $demand = $this->getUpcomingDemand($userId);
+        $capacity = $emaResult['ema'] + self::Z_90 * $emaResult['std_dev'];
+
+        // Without completion history we have no signal — never flag burnout.
+        $burnoutRisk = $hasHistory && (float) $demand['effort'] > $capacity;
+
+        $probability = $hasHistory
+            ? $this->calculateProbabilityOfSuccess(
+                $emaResult['ema'],
+                $emaResult['std_dev'],
+                (float) $demand['effort']
+            )
+            : null;
+
+        return [
+            'velocity' => $emaResult['ema'],
+            'std_dev' => $emaResult['std_dev'],
+            'capacity' => $capacity,
+            'demand' => $demand['effort'],
+            'demand_task_count' => $demand['task_count'],
+            'burnout_risk' => $burnoutRisk,
+            'probability_of_success' => $probability,
+            'data_points' => $emaResult['data_points'],
+            'weekly_totals' => $filledTotals,
+        ];
+    }
+}

--- a/apps/backend/bootstrap/app.php
+++ b/apps/backend/bootstrap/app.php
@@ -4,6 +4,7 @@ use App\Http\Middleware\EnsureAiAssistantEnabled;
 use App\Http\Middleware\EnsureApiTokenAbility;
 use App\Http\Middleware\EnsureMcpTokenAbility;
 use App\Http\Middleware\EnsureUserIsAdmin;
+use App\Http\Middleware\EnsureVelocityEnabled;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Mcp\Middleware\McpAuthMiddleware;
@@ -36,6 +37,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'admin' => EnsureUserIsAdmin::class,
             'mcp.auth' => McpAuthMiddleware::class,
             'feature.ai' => EnsureAiAssistantEnabled::class,
+            'feature.velocity' => EnsureVelocityEnabled::class,
             'token.mcp' => EnsureMcpTokenAbility::class,
             'token.api' => EnsureApiTokenAbility::class,
         ]);

--- a/apps/backend/database/factories/ItemFactory.php
+++ b/apps/backend/database/factories/ItemFactory.php
@@ -27,6 +27,7 @@ final class ItemFactory extends Factory
             'description' => fake()->optional(0.7)->paragraph(),
             'status' => fake()->randomElement(['todo', 'doing', 'done', 'wontdo']),
             'position' => fake()->numberBetween(0, 100),
+            'effort_score' => 1,
             'scheduled_date' => null,
             'due_date' => null,
             'completed_at' => null,
@@ -111,6 +112,13 @@ final class ItemFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'scheduled_date' => now()->addDays($daysAhead)->toDateString(),
+        ]);
+    }
+
+    public function withEffort(int $effort): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'effort_score' => $effort,
         ]);
     }
 }

--- a/apps/backend/database/migrations/2026_02_27_000001_add_effort_score_to_items_table.php
+++ b/apps/backend/database/migrations/2026_02_27_000001_add_effort_score_to_items_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->unsignedSmallInteger('effort_score')->default(1)->after('position');
+            $table->index(['user_id', 'status', 'completed_at'], 'items_velocity_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->dropIndex('items_velocity_index');
+            $table->dropColumn('effort_score');
+        });
+    }
+};

--- a/apps/backend/routes/api.php
+++ b/apps/backend/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\PushSubscriptionController;
 use App\Http\Controllers\TagController;
 use App\Http\Controllers\UserDiscoveryController;
 use App\Http\Controllers\UserLookupController;
+use App\Http\Controllers\VelocityController;
 use Illuminate\Support\Facades\Route;
 
 // Public API routes (no authentication required)
@@ -39,6 +40,11 @@ Route::middleware(['auth:sanctum', 'token.api', 'throttle:api'])->group(function
         Route::get('/mcp/tokens', [McpTokenController::class, 'index']);
         Route::post('/mcp/tokens', [McpTokenController::class, 'store']);
         Route::delete('/mcp/tokens/{tokenId}', [McpTokenController::class, 'destroy']);
+    });
+
+    // Velocity forecast (requires velocity feature flag)
+    Route::middleware('feature.velocity')->group(function () {
+        Route::get('/velocity/forecast', [VelocityController::class, 'forecast']);
     });
 
     // Favourite contacts (quick-pick for task assignment)

--- a/apps/backend/tests/Feature/ItemEffortScoreTest.php
+++ b/apps/backend/tests/Feature/ItemEffortScoreTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Item;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class ItemEffortScoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_effort_score_defaults_to_one(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/items', [
+                'title' => 'Default effort item',
+                'status' => 'todo',
+                'project_id' => $project->id,
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.effort_score', 1);
+
+        $this->assertDatabaseHas('items', [
+            'title' => 'Default effort item',
+            'effort_score' => 1,
+        ]);
+    }
+
+    public function test_creating_item_with_effort_score_stores_correctly(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/items', [
+                'title' => 'High effort item',
+                'status' => 'todo',
+                'project_id' => $project->id,
+                'effort_score' => 5,
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.effort_score', 5);
+
+        $this->assertDatabaseHas('items', [
+            'title' => 'High effort item',
+            'effort_score' => 5,
+        ]);
+    }
+
+    public function test_updating_effort_score_persists(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['user_id' => $user->id]);
+        $item = Item::factory()->todo()->create([
+            'user_id' => $user->id,
+            'project_id' => $project->id,
+            'effort_score' => 1,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->patchJson("/api/items/{$item->id}", [
+                'effort_score' => 8,
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.effort_score', 8);
+
+        $this->assertDatabaseHas('items', [
+            'id' => $item->id,
+            'effort_score' => 8,
+        ]);
+    }
+
+    public function test_effort_score_validation_rejects_zero(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/items', [
+                'title' => 'Bad effort',
+                'status' => 'todo',
+                'effort_score' => 0,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('effort_score');
+    }
+
+    public function test_effort_score_validation_rejects_four(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/items', [
+                'title' => 'Bad effort',
+                'status' => 'todo',
+                'effort_score' => 4,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('effort_score');
+    }
+
+    public function test_effort_score_validation_rejects_nine(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/items', [
+                'title' => 'Bad effort',
+                'status' => 'todo',
+                'effort_score' => 9,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('effort_score');
+    }
+
+    public function test_effort_score_validation_rejects_negative(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/items', [
+                'title' => 'Bad effort',
+                'status' => 'todo',
+                'effort_score' => -1,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('effort_score');
+    }
+
+    public function test_effort_score_included_in_item_api_response(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['user_id' => $user->id]);
+        Item::factory()->todo()->withEffort(3)->create([
+            'user_id' => $user->id,
+            'project_id' => $project->id,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/items');
+
+        $response->assertStatus(200);
+        $items = $response->json('data');
+        $this->assertNotEmpty($items);
+        $this->assertArrayHasKey('effort_score', $items[0]);
+        $this->assertSame(3, $items[0]['effort_score']);
+    }
+}

--- a/apps/backend/tests/Feature/VelocityForecastTest.php
+++ b/apps/backend/tests/Feature/VelocityForecastTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Item;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class VelocityForecastTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_forecast_returns_valid_response_for_authenticated_user_with_velocity_flag(): void
+    {
+        $user = User::factory()->create([
+            'feature_flags' => ['velocity' => true],
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/velocity/forecast');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'velocity',
+                    'std_dev',
+                    'capacity',
+                    'demand',
+                    'demand_task_count',
+                    'burnout_risk',
+                    'probability_of_success',
+                    'data_points',
+                    'weekly_totals',
+                ],
+            ]);
+    }
+
+    public function test_forecast_returns_401_for_unauthenticated(): void
+    {
+        $response = $this->getJson('/api/velocity/forecast');
+        $response->assertStatus(401);
+    }
+
+    public function test_forecast_returns_404_when_velocity_flag_disabled(): void
+    {
+        $user = User::factory()->create([
+            'feature_flags' => ['velocity' => false],
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/velocity/forecast');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_burnout_risk_flagged_when_demand_exceeds_velocity(): void
+    {
+        $user = User::factory()->create([
+            'feature_flags' => ['velocity' => true],
+        ]);
+
+        $project = Project::factory()->create(['user_id' => $user->id]);
+
+        // Create historical completed items with effort ~10/week across several weeks
+        for ($week = 1; $week <= 8; $week++) {
+            Item::factory()
+                ->done()
+                ->withEffort(2)
+                ->count(5)
+                ->create([
+                    'user_id' => $user->id,
+                    'project_id' => $project->id,
+                    'completed_at' => now()->subWeeks($week)->addDays(1),
+                ]);
+        }
+
+        // Create high-demand upcoming items (effort = 25 total, well above velocity ~10)
+        $today = now()->toDateString();
+        $nextWeek = now()->addDays(6)->toDateString();
+        Item::factory()
+            ->todo()
+            ->withEffort(5)
+            ->count(5)
+            ->create([
+                'user_id' => $user->id,
+                'project_id' => $project->id,
+                'due_date' => $nextWeek,
+            ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/velocity/forecast');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.burnout_risk', true);
+    }
+
+    public function test_no_burnout_when_demand_within_capacity(): void
+    {
+        $user = User::factory()->create([
+            'feature_flags' => ['velocity' => true],
+        ]);
+
+        $project = Project::factory()->create(['user_id' => $user->id]);
+
+        // Create historical completed items (~10/week)
+        for ($week = 1; $week <= 8; $week++) {
+            Item::factory()
+                ->done()
+                ->withEffort(2)
+                ->count(5)
+                ->create([
+                    'user_id' => $user->id,
+                    'project_id' => $project->id,
+                    'completed_at' => now()->subWeeks($week)->addDays(1),
+                ]);
+        }
+
+        // Low demand: 2 points total
+        Item::factory()
+            ->todo()
+            ->withEffort(1)
+            ->count(2)
+            ->create([
+                'user_id' => $user->id,
+                'project_id' => $project->id,
+                'due_date' => now()->addDays(3)->toDateString(),
+            ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/velocity/forecast');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.burnout_risk', false);
+    }
+
+    public function test_new_user_with_no_history_returns_zero_velocity(): void
+    {
+        $user = User::factory()->create([
+            'feature_flags' => ['velocity' => true],
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/velocity/forecast');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.velocity', 0)
+            ->assertJsonPath('data.burnout_risk', false)
+            ->assertJsonPath('data.probability_of_success', null);
+    }
+
+    public function test_new_user_with_demand_does_not_flag_burnout(): void
+    {
+        $user = User::factory()->create([
+            'feature_flags' => ['velocity' => true],
+        ]);
+
+        $project = Project::factory()->create(['user_id' => $user->id]);
+
+        // New user with upcoming tasks but zero completion history
+        Item::factory()
+            ->todo()
+            ->withEffort(5)
+            ->count(3)
+            ->create([
+                'user_id' => $user->id,
+                'project_id' => $project->id,
+                'due_date' => now()->addDays(3)->toDateString(),
+            ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/velocity/forecast');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.burnout_risk', false)
+            ->assertJsonPath('data.probability_of_success', null);
+    }
+}

--- a/apps/backend/tests/Unit/VelocityForecastingServiceTest.php
+++ b/apps/backend/tests/Unit/VelocityForecastingServiceTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Services\VelocityForecastingService;
+use PHPUnit\Framework\TestCase;
+
+final class VelocityForecastingServiceTest extends TestCase
+{
+    private VelocityForecastingService $service;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new VelocityForecastingService;
+    }
+
+    public function test_ema_with_known_sequence(): void
+    {
+        $efforts = [10, 12, 8, 14, 10];
+        $result = $this->service->calculateEma($efforts);
+
+        $this->assertEqualsWithDelta(10.752, $result['ema'], 0.001);
+        $this->assertGreaterThan(0.0, $result['std_dev']);
+        $this->assertSame(5, $result['data_points']);
+    }
+
+    public function test_ema_with_single_point(): void
+    {
+        $result = $this->service->calculateEma([7]);
+
+        $this->assertEqualsWithDelta(7.0, $result['ema'], 0.001);
+        $this->assertEqualsWithDelta(0.0, $result['std_dev'], 0.001);
+        $this->assertSame(1, $result['data_points']);
+    }
+
+    public function test_ema_with_empty_data(): void
+    {
+        $result = $this->service->calculateEma([]);
+
+        $this->assertEqualsWithDelta(0.0, $result['ema'], 0.001);
+        $this->assertEqualsWithDelta(0.0, $result['std_dev'], 0.001);
+        $this->assertSame(0, $result['data_points']);
+    }
+
+    public function test_normal_cdf_at_zero(): void
+    {
+        $this->assertEqualsWithDelta(0.5, $this->service->normalCdf(0.0), 0.0001);
+    }
+
+    public function test_normal_cdf_at_positive_z(): void
+    {
+        // 90th percentile
+        $this->assertEqualsWithDelta(0.95, $this->service->normalCdf(1.645), 0.001);
+    }
+
+    public function test_normal_cdf_at_negative_z(): void
+    {
+        // 10th percentile
+        $this->assertEqualsWithDelta(0.05, $this->service->normalCdf(-1.645), 0.001);
+    }
+
+    public function test_normal_cdf_extreme_values(): void
+    {
+        $this->assertEqualsWithDelta(0.0, $this->service->normalCdf(-10.0), 0.0001);
+        $this->assertEqualsWithDelta(1.0, $this->service->normalCdf(10.0), 0.0001);
+    }
+
+    public function test_probability_demand_exceeds_capacity(): void
+    {
+        // velocity ~10, std_dev ~1.5, demand = 25
+        // z = (10 - 25) / 1.5 = -10 → P ≈ 0
+        $probability = $this->service->calculateProbabilityOfSuccess(10.0, 1.5, 25.0);
+        $this->assertLessThan(0.01, $probability);
+    }
+
+    public function test_probability_demand_below_capacity(): void
+    {
+        // velocity ~10, std_dev ~1.5, demand = 5
+        // z = (10 - 5) / 1.5 = 3.33 → P ≈ 0.9996
+        $probability = $this->service->calculateProbabilityOfSuccess(10.0, 1.5, 5.0);
+        $this->assertGreaterThan(0.99, $probability);
+    }
+
+    public function test_probability_with_zero_std_dev_demand_below(): void
+    {
+        $probability = $this->service->calculateProbabilityOfSuccess(10.0, 0.0, 5.0);
+        $this->assertEqualsWithDelta(1.0, $probability, 0.001);
+    }
+
+    public function test_probability_with_zero_std_dev_demand_above(): void
+    {
+        $probability = $this->service->calculateProbabilityOfSuccess(10.0, 0.0, 15.0);
+        $this->assertEqualsWithDelta(0.0, $probability, 0.001);
+    }
+
+    public function test_gap_filling_inserts_zero_effort_weeks(): void
+    {
+        // Provide a single week of data keyed by Monday date
+        $weeklyTotals = [
+            '2026-02-23' => 10, // Monday of ISO week 9
+        ];
+
+        $filled = $this->service->fillWeekGaps($weeklyTotals, 4);
+
+        // Should have 4 entries
+        $this->assertCount(4, $filled);
+
+        // The week with data should retain its value
+        $found = false;
+        foreach ($filled as $entry) {
+            if ($entry['week_label'] === '2026-W09') {
+                $this->assertSame(10, $entry['total_effort']);
+                $found = true;
+            }
+        }
+
+        // Verify all entries have the expected structure
+        foreach ($filled as $entry) {
+            $this->assertArrayHasKey('week_label', $entry);
+            $this->assertArrayHasKey('total_effort', $entry);
+            $this->assertIsInt($entry['total_effort']);
+        }
+    }
+
+    public function test_ema_constant_input_converges(): void
+    {
+        // With constant input, EMA should converge to that constant
+        $efforts = array_fill(0, 20, 5);
+        $result = $this->service->calculateEma($efforts);
+
+        $this->assertEqualsWithDelta(5.0, $result['ema'], 0.01);
+    }
+}

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 0.16.0 - 2026-02-27
+
+### Added
+
+#### Predictive Velocity & Burnout Forecaster
+
+- **`CapacityDashboard` component**: Displays velocity forecast with probability gauge (green/amber/red), burnout risk badge, stats row (velocity/demand/capacity), and 12-week CSS bar chart — no chart libraries
+- **Effort score chip selector**: Fibonacci-scale (1, 2, 3, 5, 8) effort picker in `ItemForm`, gated behind `velocity` feature flag
+- **Effort badge in `ItemRow`**: Shows effort points for items with effort > 1 when velocity flag enabled
+- **`fetchVelocityForecast()` API function**: Fetches `GET /api/velocity/forecast` with standard response handling
+- **`VelocityForecast` TypeScript interface**: Full forecast type with weekly_totals array
+- **`velocity` feature flag**: Added to `useFeatureFlags` hook, `SettingsModal` toggle, `User` type, and `Item` type (`effort_score` field)
+
+### Changed
+
+- **`page.tsx`**: Renders `<CapacityDashboard>` when velocity enabled; passes `effort_score` through create/update flows; refreshes forecast after item changes
+- **`EditItemModal`**: Passes `effort_score` in submit values type
+- **`createItem`/`updateItem` API functions**: Accept `effort_score` parameter
+- **Version**: Bumped to v0.16.0
+
+### Tests
+
+- **`capacity-dashboard.test.tsx`**: Loading state, forecast rendering, burnout badge visibility, probability gauge percentage, API error handling
+- **`use-feature-flags.test.tsx`**: Added velocity flag toggle test
+
 ## 0.15.1 - 2026-02-21
 
 ### Changed

--- a/apps/frontend/src/__tests__/capacity-dashboard.test.tsx
+++ b/apps/frontend/src/__tests__/capacity-dashboard.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { CapacityDashboard } from "@/components/CapacityDashboard";
+import type { VelocityForecast } from "@/types";
+
+const mockForecast: VelocityForecast = {
+  velocity: 10.75,
+  std_dev: 2.1,
+  capacity: 14.2,
+  demand: 8,
+  demand_task_count: 4,
+  burnout_risk: false,
+  probability_of_success: 0.92,
+  data_points: 12,
+  weekly_totals: [
+    { week_label: "2026-W05", total_effort: 10 },
+    { week_label: "2026-W06", total_effort: 12 },
+    { week_label: "2026-W07", total_effort: 8 },
+    { week_label: "2026-W08", total_effort: 14 },
+    { week_label: "2026-W09", total_effort: 10 },
+  ],
+};
+
+const mockBurnoutForecast: VelocityForecast = {
+  ...mockForecast,
+  burnout_risk: true,
+  demand: 25,
+  probability_of_success: 0.05,
+};
+
+jest.mock("@/lib/api", () => ({
+  fetchVelocityForecast: jest.fn(),
+}));
+
+import { fetchVelocityForecast } from "@/lib/api";
+const mockedFetch = fetchVelocityForecast as jest.MockedFunction<
+  typeof fetchVelocityForecast
+>;
+
+describe("CapacityDashboard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders loading state initially", () => {
+    mockedFetch.mockReturnValue(new Promise(() => {})); // Never resolves
+    render(<CapacityDashboard />);
+    // Loading skeleton has an animate-pulse class
+    const skeleton = document.querySelector(".animate-pulse");
+    expect(skeleton).toBeInTheDocument();
+  });
+
+  test("renders forecast data after loading", async () => {
+    mockedFetch.mockResolvedValue(mockForecast);
+    render(<CapacityDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText("92%")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("10.8")).toBeInTheDocument(); // velocity
+    expect(screen.getByText("8")).toBeInTheDocument(); // demand
+  });
+
+  test("renders burnout risk badge when flagged", async () => {
+    mockedFetch.mockResolvedValue(mockBurnoutForecast);
+    render(<CapacityDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("burnout-badge")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Burnout risk")).toBeInTheDocument();
+  });
+
+  test("does not render burnout badge when no risk", async () => {
+    mockedFetch.mockResolvedValue(mockForecast);
+    render(<CapacityDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText("92%")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("burnout-badge")).not.toBeInTheDocument();
+  });
+
+  test("renders probability gauge with correct percentage", async () => {
+    mockedFetch.mockResolvedValue(mockForecast);
+    render(<CapacityDashboard />);
+
+    await waitFor(() => {
+      const gauge = screen.getByTestId("probability-gauge");
+      expect(gauge).toBeInTheDocument();
+      const bar = gauge.querySelector("div");
+      expect(bar).toHaveStyle({ width: "92%" });
+    });
+  });
+
+  test("renders empty state when probability is null (new user)", async () => {
+    const newUserForecast: VelocityForecast = {
+      ...mockForecast,
+      velocity: 0,
+      std_dev: 0,
+      capacity: 0,
+      demand: 5,
+      probability_of_success: null,
+      data_points: 12,
+    };
+    mockedFetch.mockResolvedValue(newUserForecast);
+    render(<CapacityDashboard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Complete some tasks to see predictions"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("%")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("burnout-badge")).not.toBeInTheDocument();
+  });
+
+  test("handles API error gracefully", async () => {
+    mockedFetch.mockRejectedValue(new Error("Network error"));
+    render(<CapacityDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load forecast.")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Retry")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/__tests__/item-creation-response.test.tsx
+++ b/apps/frontend/src/__tests__/item-creation-response.test.tsx
@@ -162,6 +162,7 @@ describe("Item Creation Response Handling", () => {
           status: "todo",
           project_id: null,
           position: 0,
+          effort_score: 1,
           scheduled_date: null,
           due_date: null,
           recurrence_rule: null,

--- a/apps/frontend/src/__tests__/itemrow.test.tsx
+++ b/apps/frontend/src/__tests__/itemrow.test.tsx
@@ -49,6 +49,7 @@ describe("ItemRow", () => {
     assignee_notes: null,
     is_assigned: false,
     is_delegated: false,
+    effort_score: 1,
     created_at: "2025-01-01T00:00:00Z",
     updated_at: "2025-01-01T00:00:00Z",
     deleted_at: null,

--- a/apps/frontend/src/__tests__/move-to-top.test.tsx
+++ b/apps/frontend/src/__tests__/move-to-top.test.tsx
@@ -28,6 +28,7 @@ describe("Move to Top functionality", () => {
     assignee_notes: null,
     is_assigned: false,
     is_delegated: false,
+    effort_score: 1,
     created_at: "2025-01-01T00:00:00Z",
     updated_at: "2025-01-01T00:00:00Z",
     deleted_at: null,
@@ -155,6 +156,7 @@ describe("Move to Top optimistic update", () => {
       assignee_notes: null,
       is_assigned: false,
       is_delegated: false,
+      effort_score: 1,
       deleted_at: null,
     };
 
@@ -247,6 +249,7 @@ describe("Move to Top optimistic update", () => {
       assignee_notes: null,
       is_assigned: false,
       is_delegated: false,
+      effort_score: 1,
       deleted_at: null,
     };
 

--- a/apps/frontend/src/__tests__/project-selection.test.tsx
+++ b/apps/frontend/src/__tests__/project-selection.test.tsx
@@ -269,11 +269,13 @@ describe("ItemForm with ProjectCombobox", () => {
       title: "My new task",
       description: undefined,
       project_id: "proj-1",
+      effort_score: 1,
       scheduled_date: null,
       due_date: null,
       recurrence_rule: null,
       recurrence_strategy: null,
       assignee_id: null,
+      assignee_notes: undefined,
     });
   });
 
@@ -302,11 +304,13 @@ describe("ItemForm with ProjectCombobox", () => {
       title: "Task without project",
       description: undefined,
       project_id: null,
+      effort_score: 1,
       scheduled_date: null,
       due_date: null,
       recurrence_rule: null,
       recurrence_strategy: null,
       assignee_id: null,
+      assignee_notes: undefined,
     });
   });
 });

--- a/apps/frontend/src/__tests__/use-feature-flags.test.tsx
+++ b/apps/frontend/src/__tests__/use-feature-flags.test.tsx
@@ -8,9 +8,14 @@ function Harness() {
   const { setFlag } = useFeatureFlags();
 
   return (
-    <button type="button" onClick={() => void setFlag("dates", true)}>
-      Toggle dates
-    </button>
+    <>
+      <button type="button" onClick={() => void setFlag("dates", true)}>
+        Toggle dates
+      </button>
+      <button type="button" onClick={() => void setFlag("velocity", true)}>
+        Toggle velocity
+      </button>
+    </>
   );
 }
 
@@ -29,6 +34,7 @@ describe("useFeatureFlags", () => {
         dates: false,
         delegation: false,
         ai_assistant: true,
+        velocity: false,
       },
       email_verified_at: "2025-01-01T00:00:00Z",
       created_at: "2025-01-01T00:00:00Z",
@@ -58,6 +64,53 @@ describe("useFeatureFlags", () => {
       // Only the changed key is sent; server-side merge handles the rest.
       expect(updateUser).toHaveBeenCalledWith({
         feature_flags: { dates: true },
+      });
+    });
+  });
+
+  test("sends velocity flag key when toggled", async () => {
+    const updateUser = jest.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+
+    const mockUser: User = {
+      id: "user-1",
+      name: "Test User",
+      email: "test@example.com",
+      phone: null,
+      notes: null,
+      feature_flags: {
+        dates: false,
+        delegation: false,
+        ai_assistant: false,
+        velocity: false,
+      },
+      email_verified_at: "2025-01-01T00:00:00Z",
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    render(
+      <AuthContext.Provider
+        value={{
+          user: mockUser,
+          isAuthenticated: true,
+          isLoading: false,
+          login: jest.fn(),
+          register: jest.fn(),
+          logout: jest.fn(),
+          refreshUser: jest.fn(),
+          updateUser,
+        }}
+      >
+        <Harness />
+      </AuthContext.Provider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Toggle velocity" }));
+
+    await waitFor(() => {
+      expect(updateUser).toHaveBeenCalledWith({
+        feature_flags: { velocity: true },
       });
     });
   });

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -851,17 +851,19 @@ export default function Home() {
               recurrence_strategy:
                 (v.recurrence_strategy as Item["recurrence_strategy"]) ?? null,
               assignee_id: v.assignee_id,
-            }).then(() => {
-              if (velocity) setForecastRefreshKey((k) => k + 1);
-            }).catch((error) => {
-              console.error("Failed to update item:", error);
-              const revert = (prev: Item[]) =>
-                prev.map((i) => (i.id === editingItem.id ? editingItem : i));
-              setItems(revert);
-              setAssignedItems(revert);
-              setDelegatedItems(revert);
-              showError("Failed to update task. Changes reverted.");
-            });
+            })
+              .then(() => {
+                if (velocity) setForecastRefreshKey((k) => k + 1);
+              })
+              .catch((error) => {
+                console.error("Failed to update item:", error);
+                const revert = (prev: Item[]) =>
+                  prev.map((i) => (i.id === editingItem.id ? editingItem : i));
+                setItems(revert);
+                setAssignedItems(revert);
+                setDelegatedItems(revert);
+                showError("Failed to update task. Changes reverted.");
+              });
           } else {
             // Create new item
             const tempId = `temp-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;

--- a/apps/frontend/src/components/CapacityDashboard.tsx
+++ b/apps/frontend/src/components/CapacityDashboard.tsx
@@ -60,7 +60,7 @@ export function CapacityDashboard({ refreshKey }: CapacityDashboardProps) {
 
   const hasProbability = forecast.probability_of_success !== null;
   const pct = hasProbability
-    ? Math.round(forecast.probability_of_success * 100)
+    ? Math.round(forecast.probability_of_success! * 100)
     : null;
   const gaugeColour =
     pct === null

--- a/apps/frontend/src/components/CapacityDashboard.tsx
+++ b/apps/frontend/src/components/CapacityDashboard.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchVelocityForecast } from "@/lib/api";
+import type { VelocityForecast } from "@/types";
+
+interface CapacityDashboardProps {
+  refreshKey?: number;
+}
+
+export function CapacityDashboard({ refreshKey }: CapacityDashboardProps) {
+  const [forecast, setForecast] = useState<VelocityForecast | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadForecast = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchVelocityForecast();
+      setForecast(data);
+    } catch (err) {
+      console.error("Failed to load velocity forecast:", err);
+      setError("Failed to load forecast.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadForecast();
+  }, [loadForecast, refreshKey]);
+
+  if (loading) {
+    return (
+      <div className="rounded-lg bg-white p-4 shadow-sm animate-pulse">
+        <div className="h-4 bg-slate-200 rounded w-1/3 mb-3" />
+        <div className="h-8 bg-slate-200 rounded w-full mb-2" />
+        <div className="h-3 bg-slate-100 rounded w-2/3" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg bg-red-50 border border-red-200 p-4">
+        <p className="text-sm text-red-700">{error}</p>
+        <button
+          type="button"
+          onClick={() => void loadForecast()}
+          className="mt-2 text-xs text-red-600 underline hover:no-underline"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!forecast) return null;
+
+  const hasProbability = forecast.probability_of_success !== null;
+  const pct = hasProbability
+    ? Math.round(forecast.probability_of_success * 100)
+    : null;
+  const gaugeColour =
+    pct === null
+      ? "bg-slate-300"
+      : pct >= 70
+        ? "bg-emerald-500"
+        : pct >= 40
+          ? "bg-amber-500"
+          : "bg-red-500";
+
+  // Find max for bar chart scaling
+  const maxEffort = Math.max(
+    ...forecast.weekly_totals.map((w) => w.total_effort),
+    1,
+  );
+
+  return (
+    <div className="rounded-lg bg-white p-4 shadow-sm space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+          Velocity Forecast
+        </h3>
+        {forecast.burnout_risk && (
+          <span
+            data-testid="burnout-badge"
+            className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-semibold text-red-700 border border-red-200"
+          >
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse" />
+            Burnout risk
+          </span>
+        )}
+      </div>
+
+      {/* Probability gauge */}
+      <div>
+        <div className="flex items-baseline justify-between mb-1">
+          {pct !== null ? (
+            <>
+              <span className="text-2xl font-bold text-slate-800">{pct}%</span>
+              <span className="text-xs text-slate-400">
+                chance of completion
+              </span>
+            </>
+          ) : (
+            <span className="text-sm text-slate-400">
+              Complete some tasks to see predictions
+            </span>
+          )}
+        </div>
+        <div
+          className="h-2 rounded-full bg-slate-100 overflow-hidden"
+          data-testid="probability-gauge"
+        >
+          <div
+            className={`h-full rounded-full transition-all duration-500 ${gaugeColour}`}
+            style={{ width: `${pct ?? 0}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Stats row */}
+      <div className="grid grid-cols-3 gap-3 text-center">
+        <div>
+          <p className="text-lg font-semibold text-slate-800">
+            {forecast.velocity.toFixed(1)}
+          </p>
+          <p className="text-[10px] uppercase tracking-wider text-slate-400">
+            Velocity
+          </p>
+        </div>
+        <div>
+          <p className="text-lg font-semibold text-slate-800">
+            {forecast.demand}
+          </p>
+          <p className="text-[10px] uppercase tracking-wider text-slate-400">
+            Demand
+          </p>
+        </div>
+        <div>
+          <p className="text-lg font-semibold text-slate-800">
+            {forecast.capacity.toFixed(1)}
+          </p>
+          <p className="text-[10px] uppercase tracking-wider text-slate-400">
+            Capacity
+          </p>
+        </div>
+      </div>
+
+      {/* Weekly history bar chart */}
+      <div>
+        <p className="text-[10px] uppercase tracking-wider text-slate-400 mb-2">
+          Weekly effort ({forecast.data_points} weeks)
+        </p>
+        <div className="flex items-end gap-1 h-12">
+          {forecast.weekly_totals.map((week) => {
+            const heightPct =
+              maxEffort > 0
+                ? Math.max((week.total_effort / maxEffort) * 100, 2)
+                : 2;
+            return (
+              <div
+                key={week.week_label}
+                className="flex-1 bg-blue-200 hover:bg-blue-300 rounded-t transition-colors"
+                style={{ height: `${heightPct}%` }}
+                title={`${week.week_label}: ${week.total_effort} pts`}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/EditItemModal.tsx
+++ b/apps/frontend/src/components/EditItemModal.tsx
@@ -14,6 +14,7 @@ interface EditItemModalProps {
     title: string;
     description?: string;
     project_id?: string | null;
+    effort_score?: number;
     scheduled_date?: string | null;
     due_date?: string | null;
     recurrence_rule?: string | null;
@@ -48,6 +49,7 @@ export function EditItemModal({
       title: string;
       description?: string;
       project_id?: string | null;
+      effort_score?: number;
       scheduled_date?: string | null;
       due_date?: string | null;
       recurrence_rule?: string | null;

--- a/apps/frontend/src/components/ItemForm.tsx
+++ b/apps/frontend/src/components/ItemForm.tsx
@@ -21,6 +21,7 @@ type Props = {
     title: string;
     description?: string;
     project_id?: string | null;
+    effort_score?: number;
     scheduled_date?: string | null;
     due_date?: string | null;
     recurrence_rule?: string | null;
@@ -48,7 +49,7 @@ export function ItemForm({
   favourites,
   onFavouriteToggled,
 }: Props) {
-  const { dates, delegation } = useFeatureFlags();
+  const { dates, delegation, velocity } = useFeatureFlags();
   const [title, setTitle] = useState(initial?.title ?? "");
   const [description, setDescription] = useState(initial?.description ?? "");
   const [projectId, setProjectId] = useState<string | null>(
@@ -70,6 +71,9 @@ export function ItemForm({
   const [assigneeNotes, setAssigneeNotes] = useState(
     initial?.assignee_notes ?? "",
   );
+  const [effortScore, setEffortScore] = useState<number>(
+    initial?.effort_score ?? 1,
+  );
   const [showMoreSettings, setShowMoreSettings] = useState(!!initial); // Open by default for edit mode
   const [showAssignModal, setShowAssignModal] = useState(false);
 
@@ -86,6 +90,7 @@ export function ItemForm({
           title,
           description: description || undefined,
           project_id: projectId,
+          effort_score: effortScore,
           scheduled_date: scheduledDate || null,
           due_date: dueDate || null,
           recurrence_rule: RECURRENCE_PRESET_RULES[recurrencePreset],
@@ -167,6 +172,33 @@ export function ItemForm({
                 onChange={(e) => setDescription(e.target.value)}
               />
             </div>
+
+            {velocity && (
+              <div>
+                <label className="block text-xs font-medium text-slate-500 mb-1">
+                  Effort
+                </label>
+                <div className="flex gap-2">
+                  {[1, 2, 3, 5, 8].map((value) => (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() => setEffortScore(value)}
+                      className={`w-9 h-9 rounded-full text-sm font-medium transition-all duration-200 ${
+                        effortScore === value
+                          ? "bg-[var(--blue)] text-white shadow-sm"
+                          : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                      }`}
+                    >
+                      {value}
+                    </button>
+                  ))}
+                </div>
+                <p className="mt-1 text-xs text-slate-400">
+                  Fibonacci-scale effort points for velocity tracking.
+                </p>
+              </div>
+            )}
 
             {dates && (
               <>

--- a/apps/frontend/src/components/ItemRow.tsx
+++ b/apps/frontend/src/components/ItemRow.tsx
@@ -41,7 +41,7 @@ export function ItemRow({
   dragOverId,
   onError,
 }: Props) {
-  const { dates, delegation } = useFeatureFlags();
+  const { dates, delegation, velocity } = useFeatureFlags();
 
   const [optimisticItem, addOptimistic] = useOptimistic(
     item,
@@ -231,6 +231,13 @@ export function ItemRow({
               {tag.name}
             </span>
           ))}
+          {velocity && optimisticItem.effort_score > 1 && (
+            <span
+              className={`text-xs font-medium px-2 py-0.5 rounded-full transition-colors duration-200 ${isCompleted || isCancelled ? "bg-slate-100 text-slate-300" : "bg-sky-100 text-sky-700 border border-sky-200"}`}
+            >
+              {optimisticItem.effort_score} pts
+            </span>
+          )}
           {delegation &&
             optimisticItem.is_delegated &&
             optimisticItem.assignee && (

--- a/apps/frontend/src/components/SettingsModal.tsx
+++ b/apps/frontend/src/components/SettingsModal.tsx
@@ -16,7 +16,7 @@ interface SettingsModalProps {
  */
 export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
-  const { dates, delegation, aiAssistant, setFlag } = useFeatureFlags();
+  const { dates, delegation, aiAssistant, velocity, setFlag } = useFeatureFlags();
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [mcpTokens, setMcpTokens] = useState<McpToken[]>([]);
@@ -304,6 +304,41 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                   </span>
                 </div>
               </div>
+
+              {/* Velocity Forecaster toggle */}
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => handleToggle("velocity", !velocity)}
+                  disabled={saving}
+                  className={`
+                    relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full
+                    border-2 border-transparent transition-colors duration-200 ease-in-out
+                    focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
+                    ${velocity ? "bg-blue-600" : "bg-gray-200"}
+                    ${saving ? "opacity-50 cursor-not-allowed" : ""}
+                  `}
+                  role="switch"
+                  aria-checked={velocity}
+                  aria-label="Velocity Forecaster"
+                >
+                  <span
+                    className={`
+                      pointer-events-none inline-block h-5 w-5 transform rounded-full
+                      bg-white shadow ring-0 transition duration-200 ease-in-out
+                      ${velocity ? "translate-x-5" : "translate-x-0"}
+                    `}
+                  />
+                </button>
+                <div className="flex flex-col">
+                  <span className="text-sm font-medium text-gray-900">
+                    Velocity Forecaster
+                  </span>
+                  <span className="text-xs text-gray-500">
+                    Predictive burnout detection and capacity planning
+                  </span>
+                </div>
+              </div>
             </div>
           </section>
 
@@ -476,7 +511,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
           {/* Version Info */}
           <section className="pt-4 border-t border-gray-100">
             <p className="text-xs text-gray-400 text-center">
-              Ballistic v0.15.0
+              Ballistic v0.16.0
             </p>
           </section>
         </div>

--- a/apps/frontend/src/components/SettingsModal.tsx
+++ b/apps/frontend/src/components/SettingsModal.tsx
@@ -16,7 +16,8 @@ interface SettingsModalProps {
  */
 export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
-  const { dates, delegation, aiAssistant, velocity, setFlag } = useFeatureFlags();
+  const { dates, delegation, aiAssistant, velocity, setFlag } =
+    useFeatureFlags();
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [mcpTokens, setMcpTokens] = useState<McpToken[]>([]);

--- a/apps/frontend/src/components/SettingsModal.tsx
+++ b/apps/frontend/src/components/SettingsModal.tsx
@@ -80,7 +80,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   }, [isOpen, aiAssistant, loadMcpTokens]);
 
   async function handleToggle(
-    flag: "dates" | "delegation" | "ai_assistant",
+    flag: "dates" | "delegation" | "ai_assistant" | "velocity",
     value: boolean,
   ) {
     if (saving) return;

--- a/apps/frontend/src/contexts/AuthContext.tsx
+++ b/apps/frontend/src/contexts/AuthContext.tsx
@@ -17,7 +17,11 @@ import {
   logout as authLogout,
   AuthError,
 } from "@/lib/auth";
-import { fetchUser, updateUser as apiUpdateUser, type UserUpdatePayload } from "@/lib/api";
+import {
+  fetchUser,
+  updateUser as apiUpdateUser,
+  type UserUpdatePayload,
+} from "@/lib/api";
 
 interface AuthContextType {
   user: User | null;
@@ -98,12 +102,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const updateUser = useCallback(async (data: UserUpdatePayload) => {
-      const updatedUser = await apiUpdateUser(data);
-      setUser(updatedUser);
-      setStoredUser(updatedUser);
-    },
-    [],
-  );
+    const updatedUser = await apiUpdateUser(data);
+    setUser(updatedUser);
+    setStoredUser(updatedUser);
+  }, []);
 
   const value: AuthContextType = {
     user,

--- a/apps/frontend/src/hooks/useFeatureFlags.ts
+++ b/apps/frontend/src/hooks/useFeatureFlags.ts
@@ -7,12 +7,14 @@ interface FeatureFlags {
   dates: boolean;
   delegation: boolean;
   ai_assistant: boolean;
+  velocity: boolean;
 }
 
 const DEFAULTS: FeatureFlags = {
   dates: false,
   delegation: false,
   ai_assistant: false,
+  velocity: false,
 };
 
 export function useFeatureFlags() {
@@ -33,11 +35,12 @@ export function useFeatureFlags() {
       dates: user.feature_flags.dates ?? false,
       delegation: user.feature_flags.delegation ?? false,
       ai_assistant: user.feature_flags.ai_assistant ?? false,
+      velocity: user.feature_flags.velocity ?? false,
     };
   }, [user?.feature_flags]);
 
   const setFlag = useCallback(
-    async (flag: "dates" | "delegation" | "ai_assistant", value: boolean) => {
+    async (flag: "dates" | "delegation" | "ai_assistant" | "velocity", value: boolean) => {
       // Send only the changed key — the server merges it with the stored flags,
       // which avoids a multi-tab race condition where two concurrent updates
       // would overwrite each other's changes.
@@ -55,6 +58,7 @@ export function useFeatureFlags() {
     dates: flags.dates,
     delegation: flags.delegation,
     aiAssistant: flags.ai_assistant,
+    velocity: flags.velocity,
     setFlag,
     loaded: user !== null,
   };

--- a/apps/frontend/src/hooks/useFeatureFlags.ts
+++ b/apps/frontend/src/hooks/useFeatureFlags.ts
@@ -40,7 +40,10 @@ export function useFeatureFlags() {
   }, [user?.feature_flags]);
 
   const setFlag = useCallback(
-    async (flag: "dates" | "delegation" | "ai_assistant" | "velocity", value: boolean) => {
+    async (
+      flag: "dates" | "delegation" | "ai_assistant" | "velocity",
+      value: boolean,
+    ) => {
       // Send only the changed key — the server merges it with the stored flags,
       // which avoids a multi-tab race condition where two concurrent updates
       // would overwrite each other's changes.

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -7,6 +7,7 @@ import type {
   User,
   UserLookup,
   NotificationsResponse,
+  VelocityForecast,
 } from "@/types";
 import { getAuthHeaders, clearToken } from "./auth";
 
@@ -222,6 +223,7 @@ export async function createItem(payload: {
   status: Status;
   project_id?: string | null;
   position?: number;
+  effort_score?: number;
   scheduled_date?: string | null;
   due_date?: string | null;
   recurrence_rule?: string | null;
@@ -237,6 +239,7 @@ export async function createItem(payload: {
       status: payload.status,
       project_id: payload.project_id || null,
       position: payload.position ?? 0,
+      effort_score: payload.effort_score ?? 1,
       scheduled_date: payload.scheduled_date || null,
       due_date: payload.due_date || null,
       recurrence_rule: payload.recurrence_rule || null,
@@ -280,6 +283,7 @@ export async function updateItem(
       | "assignee_notes"
       | "project_id"
       | "position"
+      | "effort_score"
       | "scheduled_date"
       | "due_date"
       | "recurrence_rule"
@@ -591,6 +595,27 @@ export async function deletePushSubscription(
   );
 
   return handleResponse<{ message: string }>(response);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Velocity Forecast
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch the velocity forecast for the authenticated user.
+ * Requires the velocity feature flag to be enabled.
+ */
+export async function fetchVelocityForecast(): Promise<VelocityForecast> {
+  const response = await fetch(buildUrl("/api/velocity/forecast"), {
+    method: "GET",
+    headers: getAuthHeaders(),
+    cache: "no-store",
+  });
+
+  const payload = await handleResponse<
+    VelocityForecast | { data?: VelocityForecast }
+  >(response);
+  return extractData(payload);
 }
 
 /**

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -10,6 +10,7 @@ export interface User {
     dates: boolean;
     delegation: boolean;
     ai_assistant: boolean;
+    velocity: boolean;
   } | null;
   email_verified_at: string | null;
   created_at: string;
@@ -53,6 +54,7 @@ export interface Item {
   assignee_notes: string | null;
   status: Status;
   position: number;
+  effort_score: number;
   scheduled_date: string | null;
   due_date: string | null;
   completed_at: string | null;
@@ -125,3 +127,15 @@ export const RECURRENCE_PRESET_RULES: Record<RecurrencePreset, string | null> =
     weekly: "FREQ=WEEKLY",
     monthly: "FREQ=MONTHLY",
   };
+
+export interface VelocityForecast {
+  velocity: number;
+  std_dev: number;
+  capacity: number;
+  demand: number;
+  demand_task_count: number;
+  burnout_risk: boolean;
+  probability_of_success: number | null;
+  data_points: number;
+  weekly_totals: { week_label: string; total_effort: number }[];
+}


### PR DESCRIPTION
## Summary
- EMA-based velocity engine with burnout detection at the 90th percentile capacity threshold, gated behind the `velocity` feature flag
- `effort_score` column on items (Fibonacci scale 1–8) with SQL-level weekly aggregation for velocity calculation
- `GET /api/velocity/forecast` endpoint with `EnsureVelocityEnabled` middleware
- Frontend `CapacityDashboard` with probability gauge, burnout badge, bar chart; effort score chip selector in `ItemForm`; velocity toggle in settings

## Test plan
- [x] Backend: 528 passed, 0 failed (Pint, PHPUnit unit + feature)
- [x] Frontend: 52 passed, 0 failed (ESLint, Jest)
- [x] Acceptance: velocity ≈ 10, assign 25 points → `burnout_risk: true`
- [x] New user with no history → no burnout flag, `probability_of_success: null`
- [x] Effort score CRUD: default 1, Fibonacci validation, API response inclusion
- [x] Soft-deleted items excluded from both velocity and demand queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)