### PR TITLE
Add admin-controlled global feature flags

### DIFF
--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-02-27
+
+### Added
+
+#### Admin-Controlled Global Feature Flags
+
+- **`app_settings` table**: New table for storing application-wide settings as key–value pairs with JSON values
+- **`AppSetting` model**: Final model with static `get()`/`set()` helpers using 60-second cache TTL, and `globalFeatureFlags()` returning safe defaults (all `true`) when no row exists
+- **`Admin\SettingsController`**: New controller with `showFeatures` (GET) and `updateFeatures` (PUT) endpoints for admin feature flag management; supports partial updates and rejects unknown keys
+- **Admin routes**: `GET /api/admin/settings/features` and `PUT /api/admin/settings/features` under admin middleware
+- **`available_feature_flags` in user API response**: `UserResource` now includes globally available flags alongside the user's own `feature_flags`, using the cached `AppSetting` lookup
+- **Global flag enforcement in `UserController::update`**: Returns 422 if a user attempts to enable a flag that the admin has globally disabled; disabling own flags is always permitted
+- **Global flag check in `EnsureAiAssistantEnabled` middleware**: Checks the global `ai_assistant` flag before the user-level flag, returning 404 when globally disabled
+
+### Tests
+
+- **`GlobalFeatureFlagsTest`**: 12 tests covering admin read/write, non-admin rejection, partial updates, arbitrary key rejection, user enable/disable, user response shape, middleware behaviour, and safe defaults
+
 ## [0.15.1] - 2026-02-21
 
 ### Changed

--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2026-03-08
+
+### Changed
+
+#### Pre-Merge Hardening
+
+- **`Admin\SettingsController`**: Refactored to use `UpdateFeatureFlagsRequest` Form Request class instead of inline validation, consistent with project conventions
+- **`UpdateFeatureFlagsRequest`**: New Form Request with `featureFlags()` accessor that validates and filters to known keys
+- **`AppSetting` model**: Fixed `casts()` PHPDoc return type from `array<string, string>` to `array{value: string}`
+- **Migration idempotency**: Changed `DB::table()->insert()` to `updateOrInsert()` in the `app_settings` seed to prevent unique constraint failures on re-run
+- **`EnsureAiAssistantEnabled` middleware**: Added `aria-modal` and `role="dialog"` attributes to all modal containers for accessibility (frontend)
+
 ## [0.16.0] - 2026-02-27
 
 ### Added

--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2] - 2026-03-08
+
+### Changed
+
+#### Pre-Merge Bulletproofing
+
+- **`UpdateFeatureFlagsRequest::authorize()`**: Changed from unconditional `return true` to `$this->user()?->is_admin === true` — adds defence-in-depth so the admin restriction is enforced at the Form Request level as well as the route middleware
+- **`UserController::update`**: Replaced manual `response()->json([...], 422)` with `throw ValidationException::withMessages($errors)` for idiomatic Laravel error handling; removed `JsonResponse` from the union return type leaving a clean `UserResource` return
+- **`AppSetting` migration**: Changed seed from `updateOrInsert` (which overwrites `created_at` on conflict) to `insertOrIgnore` — re-running the migration never overwrites admin-configured values
+- **Backend changelog 0.16.1**: Removed stray frontend accessibility note that was incorrectly attributed to the `EnsureAiAssistantEnabled` middleware
+
+### Tests
+
+- **`GlobalFeatureFlagsTest`**: Added `test_non_boolean_flag_value_is_rejected` and `test_integer_flag_value_is_rejected` to verify validation rules reject non-boolean flag values with 422
+
 ## [0.16.1] - 2026-03-08
 
 ### Changed
@@ -15,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`UpdateFeatureFlagsRequest`**: New Form Request with `featureFlags()` accessor that validates and filters to known keys
 - **`AppSetting` model**: Fixed `casts()` PHPDoc return type from `array<string, string>` to `array{value: string}`
 - **Migration idempotency**: Changed `DB::table()->insert()` to `updateOrInsert()` in the `app_settings` seed to prevent unique constraint failures on re-run
-- **`EnsureAiAssistantEnabled` middleware**: Added `aria-modal` and `role="dialog"` attributes to all modal containers for accessibility (frontend)
 
 ## [0.16.0] - 2026-02-27
 

--- a/apps/backend/app/Http/Controllers/Admin/SettingsController.php
+++ b/apps/backend/app/Http/Controllers/Admin/SettingsController.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\AppSetting;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class SettingsController extends Controller
+{
+    /**
+     * Show the current global feature flags.
+     */
+    public function showFeatures(): JsonResponse
+    {
+        return response()->json([
+            'data' => AppSetting::globalFeatureFlags(),
+        ]);
+    }
+
+    /**
+     * Update one or more global feature flags (partial update).
+     */
+    public function updateFeatures(Request $request): JsonResponse
+    {
+        $allowedKeys = ['dates', 'delegation', 'ai_assistant'];
+
+        $validated = $request->validate([
+            'dates' => ['sometimes', 'boolean'],
+            'delegation' => ['sometimes', 'boolean'],
+            'ai_assistant' => ['sometimes', 'boolean'],
+        ]);
+
+        $incoming = array_intersect_key($validated, array_flip($allowedKeys));
+
+        if (empty($incoming)) {
+            return response()->json([
+                'data' => AppSetting::globalFeatureFlags(),
+            ]);
+        }
+
+        $current = AppSetting::globalFeatureFlags();
+        $merged = array_merge($current, $incoming);
+
+        AppSetting::set('feature_flags', $merged);
+
+        return response()->json([
+            'data' => $merged,
+        ]);
+    }
+}

--- a/apps/backend/app/Http/Controllers/Admin/SettingsController.php
+++ b/apps/backend/app/Http/Controllers/Admin/SettingsController.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\UpdateFeatureFlagsRequest;
 use App\Models\AppSetting;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 
 final class SettingsController extends Controller
 {
@@ -24,17 +24,9 @@ final class SettingsController extends Controller
     /**
      * Update one or more global feature flags (partial update).
      */
-    public function updateFeatures(Request $request): JsonResponse
+    public function updateFeatures(UpdateFeatureFlagsRequest $request): JsonResponse
     {
-        $allowedKeys = ['dates', 'delegation', 'ai_assistant'];
-
-        $validated = $request->validate([
-            'dates' => ['sometimes', 'boolean'],
-            'delegation' => ['sometimes', 'boolean'],
-            'ai_assistant' => ['sometimes', 'boolean'],
-        ]);
-
-        $incoming = array_intersect_key($validated, array_flip($allowedKeys));
+        $incoming = $request->featureFlags();
 
         if (empty($incoming)) {
             return response()->json([

--- a/apps/backend/app/Http/Controllers/Api/UserController.php
+++ b/apps/backend/app/Http/Controllers/Api/UserController.php
@@ -6,7 +6,9 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\UserResource;
+use App\Models\AppSetting;
 use App\Models\User;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
@@ -30,7 +32,7 @@ final class UserController extends Controller
     /**
      * Update the authenticated user's profile.
      */
-    public function update(Request $request): UserResource
+    public function update(Request $request): UserResource|JsonResponse
     {
         /** @var User $user */
         $user = $request->user();
@@ -62,6 +64,22 @@ final class UserController extends Controller
         if (array_key_exists('feature_flags', $validated) && is_array($validated['feature_flags'])) {
             $allowedFlagKeys = ['dates', 'delegation', 'ai_assistant'];
             $incomingFlags = array_intersect_key($validated['feature_flags'], array_flip($allowedFlagKeys));
+
+            // Reject enabling flags that are globally disabled by admin
+            $globalFlags = AppSetting::globalFeatureFlags();
+            $errors = [];
+            foreach ($incomingFlags as $flag => $value) {
+                if ($value === true && ($globalFlags[$flag] ?? true) === false) {
+                    $errors["feature_flags.{$flag}"] = ["The {$flag} feature is not currently available."];
+                }
+            }
+
+            if (! empty($errors)) {
+                return response()->json([
+                    'message' => 'One or more features are not currently available.',
+                    'errors' => $errors,
+                ], 422);
+            }
 
             $validated['feature_flags'] = array_merge(
                 $user->feature_flags ?? [],

--- a/apps/backend/app/Http/Controllers/Api/UserController.php
+++ b/apps/backend/app/Http/Controllers/Api/UserController.php
@@ -8,12 +8,12 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\UserResource;
 use App\Models\AppSetting;
 use App\Models\User;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 
 final class UserController extends Controller
 {
@@ -32,7 +32,7 @@ final class UserController extends Controller
     /**
      * Update the authenticated user's profile.
      */
-    public function update(Request $request): UserResource|JsonResponse
+    public function update(Request $request): UserResource
     {
         /** @var User $user */
         $user = $request->user();
@@ -75,10 +75,7 @@ final class UserController extends Controller
             }
 
             if (! empty($errors)) {
-                return response()->json([
-                    'message' => 'One or more features are not currently available.',
-                    'errors' => $errors,
-                ], 422);
+                throw ValidationException::withMessages($errors);
             }
 
             $validated['feature_flags'] = array_merge(

--- a/apps/backend/app/Http/Middleware/EnsureAiAssistantEnabled.php
+++ b/apps/backend/app/Http/Middleware/EnsureAiAssistantEnabled.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Models\AppSetting;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -13,7 +14,8 @@ final class EnsureAiAssistantEnabled
     /**
      * Handle an incoming request.
      *
-     * Ensures the authenticated user has enabled the AI assistant feature flag.
+     * Ensures the AI assistant feature is globally enabled AND the authenticated
+     * user has enabled their AI assistant feature flag.
      * Returns 404 if the feature is not enabled (to not reveal the endpoint exists).
      *
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
@@ -26,6 +28,13 @@ final class EnsureAiAssistantEnabled
             abort(401);
         }
 
+        // Check global feature flag first
+        $globalFlags = AppSetting::globalFeatureFlags();
+        if (! ($globalFlags['ai_assistant'] ?? true)) {
+            abort(404);
+        }
+
+        // Check user-level feature flag
         $flags = $user->feature_flags ?? [];
         $aiEnabled = $flags['ai_assistant'] ?? false;
 

--- a/apps/backend/app/Http/Requests/Admin/UpdateFeatureFlagsRequest.php
+++ b/apps/backend/app/Http/Requests/Admin/UpdateFeatureFlagsRequest.php
@@ -10,7 +10,7 @@ final class UpdateFeatureFlagsRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return true;
+        return $this->user()?->is_admin === true;
     }
 
     /**

--- a/apps/backend/app/Http/Requests/Admin/UpdateFeatureFlagsRequest.php
+++ b/apps/backend/app/Http/Requests/Admin/UpdateFeatureFlagsRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class UpdateFeatureFlagsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'dates' => ['sometimes', 'boolean'],
+            'delegation' => ['sometimes', 'boolean'],
+            'ai_assistant' => ['sometimes', 'boolean'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'dates.boolean' => 'The dates flag must be true or false.',
+            'delegation.boolean' => 'The delegation flag must be true or false.',
+            'ai_assistant.boolean' => 'The AI assistant flag must be true or false.',
+        ];
+    }
+
+    /**
+     * Only allow the known feature flag keys through.
+     *
+     * @return array<string, bool>
+     */
+    public function featureFlags(): array
+    {
+        return array_intersect_key(
+            $this->validated(),
+            array_flip(['dates', 'delegation', 'ai_assistant'])
+        );
+    }
+}

--- a/apps/backend/app/Http/Resources/UserResource.php
+++ b/apps/backend/app/Http/Resources/UserResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Resources;
 
+use App\Models\AppSetting;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -26,6 +27,7 @@ final class UserResource extends JsonResource
                 ['dates' => false, 'delegation' => false, 'ai_assistant' => false],
                 $this->feature_flags ?? []
             ),
+            'available_feature_flags' => AppSetting::globalFeatureFlags(),
             'email_verified_at' => $this->email_verified_at?->toIso8601String(),
             'is_admin' => $this->is_admin,
             'created_at' => $this->created_at?->toIso8601String(),

--- a/apps/backend/app/Models/AppSetting.php
+++ b/apps/backend/app/Models/AppSetting.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
+
+final class AppSetting extends Model
+{
+    protected $fillable = ['key', 'value'];
+
+    /**
+     * @return array<string, string>
+     */
+    #[\Override]
+    protected function casts(): array
+    {
+        return [
+            'value' => 'array',
+        ];
+    }
+
+    /**
+     * Get a setting value by key, with caching.
+     */
+    public static function get(string $key, mixed $default = null): mixed
+    {
+        return Cache::remember("app_setting:{$key}", 60, function () use ($key, $default) {
+            $setting = self::where('key', $key)->first();
+
+            return $setting?->value ?? $default;
+        });
+    }
+
+    /**
+     * Set a setting value by key, busting the cache.
+     */
+    public static function set(string $key, mixed $value): void
+    {
+        self::updateOrCreate(
+            ['key' => $key],
+            ['value' => $value]
+        );
+
+        Cache::forget("app_setting:{$key}");
+    }
+
+    /**
+     * Get the global feature flags, merged with safe defaults (all true).
+     *
+     * @return array<string, bool>
+     */
+    public static function globalFeatureFlags(): array
+    {
+        $defaults = [
+            'dates' => true,
+            'delegation' => true,
+            'ai_assistant' => true,
+        ];
+
+        /** @var array<string, bool>|null $stored */
+        $stored = self::get('feature_flags');
+
+        if (! is_array($stored)) {
+            return $defaults;
+        }
+
+        return array_merge($defaults, $stored);
+    }
+}

--- a/apps/backend/app/Models/AppSetting.php
+++ b/apps/backend/app/Models/AppSetting.php
@@ -49,6 +49,8 @@ final class AppSetting extends Model
 
     /**
      * Get the global feature flags, merged with safe defaults (all true).
+     * Results are cached for 60 seconds via the application cache, so
+     * repeated calls within a request hit only the cache, not the database.
      *
      * @return array<string, bool>
      */

--- a/apps/backend/app/Models/AppSetting.php
+++ b/apps/backend/app/Models/AppSetting.php
@@ -12,7 +12,7 @@ final class AppSetting extends Model
     protected $fillable = ['key', 'value'];
 
     /**
-     * @return array<string, string>
+     * @return array{value: string}
      */
     #[\Override]
     protected function casts(): array

--- a/apps/backend/database/migrations/2026_02_27_062152_create_app_settings_table.php
+++ b/apps/backend/database/migrations/2026_02_27_062152_create_app_settings_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('app_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->json('value')->nullable();
+            $table->timestamps();
+        });
+
+        // Seed the default feature flags so existing behaviour is preserved
+        DB::table('app_settings')->insert([
+            'key' => 'feature_flags',
+            'value' => json_encode([
+                'dates' => true,
+                'delegation' => true,
+                'ai_assistant' => true,
+            ]),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('app_settings');
+    }
+};

--- a/apps/backend/database/migrations/2026_02_27_062152_create_app_settings_table.php
+++ b/apps/backend/database/migrations/2026_02_27_062152_create_app_settings_table.php
@@ -22,16 +22,18 @@ return new class extends Migration
         });
 
         // Seed the default feature flags so existing behaviour is preserved
-        DB::table('app_settings')->insert([
-            'key' => 'feature_flags',
-            'value' => json_encode([
-                'dates' => true,
-                'delegation' => true,
-                'ai_assistant' => true,
-            ]),
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
+        DB::table('app_settings')->updateOrInsert(
+            ['key' => 'feature_flags'],
+            [
+                'value' => json_encode([
+                    'dates' => true,
+                    'delegation' => true,
+                    'ai_assistant' => true,
+                ]),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
     }
 
     /**

--- a/apps/backend/database/migrations/2026_02_27_062152_create_app_settings_table.php
+++ b/apps/backend/database/migrations/2026_02_27_062152_create_app_settings_table.php
@@ -21,19 +21,18 @@ return new class extends Migration
             $table->timestamps();
         });
 
-        // Seed the default feature flags so existing behaviour is preserved
-        DB::table('app_settings')->updateOrInsert(
-            ['key' => 'feature_flags'],
-            [
-                'value' => json_encode([
-                    'dates' => true,
-                    'delegation' => true,
-                    'ai_assistant' => true,
-                ]),
-                'created_at' => now(),
-                'updated_at' => now(),
-            ]
-        );
+        // Seed the default feature flags only if no row exists yet,
+        // so re-running the migration never overwrites admin-configured values.
+        DB::table('app_settings')->insertOrIgnore([
+            'key' => 'feature_flags',
+            'value' => json_encode([
+                'dates' => true,
+                'delegation' => true,
+                'ai_assistant' => true,
+            ]),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
     }
 
     /**

--- a/apps/backend/routes/api.php
+++ b/apps/backend/routes/api.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Admin\SettingsController as AdminSettingsController;
 use App\Http\Controllers\Admin\StatsController as AdminStatsController;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
 use App\Http\Controllers\Api\AuthController;
@@ -90,5 +91,7 @@ Route::middleware(['auth:sanctum', 'token.api', 'throttle:api'])->group(function
         Route::apiResource('users', AdminUserController::class);
         Route::get('stats', [AdminStatsController::class, 'index']);
         Route::get('stats/user-activity', [AdminStatsController::class, 'userActivity']);
+        Route::get('settings/features', [AdminSettingsController::class, 'showFeatures']);
+        Route::put('settings/features', [AdminSettingsController::class, 'updateFeatures']);
     });
 });

--- a/apps/backend/tests/Feature/Admin/GlobalFeatureFlagsTest.php
+++ b/apps/backend/tests/Feature/Admin/GlobalFeatureFlagsTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Auth\TokenAbility;
+use App\Models\AppSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+final class GlobalFeatureFlagsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── Admin read ───────────────────────────────────────────────
+
+    public function test_admin_can_read_global_feature_flags(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        AppSetting::set('feature_flags', [
+            'dates' => true,
+            'delegation' => false,
+            'ai_assistant' => true,
+        ]);
+
+        $response = $this->actingAs($admin)->getJson('/api/admin/settings/features');
+
+        $response->assertOk()
+            ->assertJsonPath('data.dates', true)
+            ->assertJsonPath('data.delegation', false)
+            ->assertJsonPath('data.ai_assistant', true);
+    }
+
+    public function test_non_admin_cannot_read_global_feature_flags(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->getJson('/api/admin/settings/features');
+
+        $response->assertForbidden();
+    }
+
+    // ── Admin update ─────────────────────────────────────────────
+
+    public function test_admin_can_update_global_feature_flags(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $response = $this->actingAs($admin)->putJson('/api/admin/settings/features', [
+            'dates' => false,
+            'delegation' => false,
+            'ai_assistant' => false,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.dates', false)
+            ->assertJsonPath('data.delegation', false)
+            ->assertJsonPath('data.ai_assistant', false);
+
+        // Verify persistence
+        Cache::flush();
+        $flags = AppSetting::globalFeatureFlags();
+        $this->assertFalse($flags['dates']);
+        $this->assertFalse($flags['delegation']);
+        $this->assertFalse($flags['ai_assistant']);
+    }
+
+    public function test_partial_update_preserves_other_flags(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        AppSetting::set('feature_flags', [
+            'dates' => true,
+            'delegation' => true,
+            'ai_assistant' => true,
+        ]);
+
+        $response = $this->actingAs($admin)->putJson('/api/admin/settings/features', [
+            'delegation' => false,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.dates', true)
+            ->assertJsonPath('data.delegation', false)
+            ->assertJsonPath('data.ai_assistant', true);
+    }
+
+    public function test_non_admin_cannot_update_global_feature_flags(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->putJson('/api/admin/settings/features', [
+            'dates' => false,
+        ]);
+
+        $response->assertForbidden();
+    }
+
+    public function test_arbitrary_keys_are_rejected(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $response = $this->actingAs($admin)->putJson('/api/admin/settings/features', [
+            'dates' => false,
+            'evil_flag' => true,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.dates', false);
+
+        Cache::flush();
+        $flags = AppSetting::globalFeatureFlags();
+        $this->assertArrayNotHasKey('evil_flag', $flags);
+    }
+
+    // ── User cannot enable globally disabled flag ────────────────
+
+    public function test_user_cannot_enable_globally_disabled_flag(): void
+    {
+        $user = User::factory()->create([
+            'feature_flags' => [
+                'dates' => false,
+                'delegation' => false,
+                'ai_assistant' => false,
+            ],
+        ]);
+        $token = $user->createToken('api-client', [TokenAbility::Api->value])->plainTextToken;
+
+        AppSetting::set('feature_flags', [
+            'dates' => false,
+            'delegation' => true,
+            'ai_assistant' => true,
+        ]);
+
+        $response = $this->withToken($token)->patchJson('/api/user', [
+            'feature_flags' => ['dates' => true],
+        ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['feature_flags.dates']);
+    }
+
+    public function test_user_can_disable_own_flag_regardless_of_global_state(): void
+    {
+        $user = User::factory()->create([
+            'feature_flags' => [
+                'dates' => true,
+                'delegation' => true,
+                'ai_assistant' => true,
+            ],
+        ]);
+        $token = $user->createToken('api-client', [TokenAbility::Api->value])->plainTextToken;
+
+        AppSetting::set('feature_flags', [
+            'dates' => false,
+            'delegation' => true,
+            'ai_assistant' => true,
+        ]);
+
+        $response = $this->withToken($token)->patchJson('/api/user', [
+            'feature_flags' => ['dates' => false],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.feature_flags.dates', false);
+    }
+
+    // ── User response includes available_feature_flags ───────────
+
+    public function test_user_response_includes_available_feature_flags(): void
+    {
+        $user = User::factory()->create([
+            'feature_flags' => [
+                'dates' => true,
+                'delegation' => false,
+                'ai_assistant' => true,
+            ],
+        ]);
+        $token = $user->createToken('api-client', [TokenAbility::Api->value])->plainTextToken;
+
+        AppSetting::set('feature_flags', [
+            'dates' => true,
+            'delegation' => false,
+            'ai_assistant' => true,
+        ]);
+
+        $response = $this->withToken($token)->getJson('/api/user');
+
+        $response->assertOk()
+            ->assertJsonPath('data.feature_flags.dates', true)
+            ->assertJsonPath('data.feature_flags.delegation', false)
+            ->assertJsonPath('data.available_feature_flags.dates', true)
+            ->assertJsonPath('data.available_feature_flags.delegation', false)
+            ->assertJsonPath('data.available_feature_flags.ai_assistant', true);
+    }
+
+    // ── Middleware blocks when global flag is disabled ────────────
+
+    public function test_middleware_blocks_when_global_ai_assistant_disabled(): void
+    {
+        $user = User::factory()->create([
+            'feature_flags' => ['ai_assistant' => true],
+        ]);
+        $token = $user->createToken('api-client', [TokenAbility::Api->value])->plainTextToken;
+
+        AppSetting::set('feature_flags', [
+            'dates' => true,
+            'delegation' => true,
+            'ai_assistant' => false,
+        ]);
+
+        $response = $this->withToken($token)->getJson('/api/mcp/tokens');
+
+        $response->assertNotFound();
+    }
+
+    public function test_middleware_blocks_when_user_ai_assistant_disabled(): void
+    {
+        $user = User::factory()->create([
+            'feature_flags' => ['ai_assistant' => false],
+        ]);
+        $token = $user->createToken('api-client', [TokenAbility::Api->value])->plainTextToken;
+
+        AppSetting::set('feature_flags', [
+            'dates' => true,
+            'delegation' => true,
+            'ai_assistant' => true,
+        ]);
+
+        $response = $this->withToken($token)->getJson('/api/mcp/tokens');
+
+        $response->assertNotFound();
+    }
+
+    // ── Defaults when no setting row exists ──────────────────────
+
+    public function test_defaults_all_true_when_no_setting_row_exists(): void
+    {
+        // Do not seed any AppSetting row
+        $flags = AppSetting::globalFeatureFlags();
+
+        $this->assertTrue($flags['dates']);
+        $this->assertTrue($flags['delegation']);
+        $this->assertTrue($flags['ai_assistant']);
+    }
+}

--- a/apps/backend/tests/Feature/Admin/GlobalFeatureFlagsTest.php
+++ b/apps/backend/tests/Feature/Admin/GlobalFeatureFlagsTest.php
@@ -247,4 +247,30 @@ final class GlobalFeatureFlagsTest extends TestCase
         $this->assertTrue($flags['delegation']);
         $this->assertTrue($flags['ai_assistant']);
     }
+
+    // ── Validation — non-boolean values rejected ──────────────────
+
+    public function test_non_boolean_flag_value_is_rejected(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $response = $this->actingAs($admin)->putJson('/api/admin/settings/features', [
+            'dates' => 'not_a_boolean',
+        ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['dates']);
+    }
+
+    public function test_integer_flag_value_is_rejected(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $response = $this->actingAs($admin)->putJson('/api/admin/settings/features', [
+            'delegation' => 42,
+        ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['delegation']);
+    }
 }

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.15.2 - 2026-02-27
+
+### Fixed
+
+- **Settings modal scrollability**: Converted from a bottom sheet to a centred popup with `max-h-[90vh]` and `overflow-y-auto`, so all content is reachable when the modal exceeds viewport height
+
 ## 0.15.1 - 2026-02-21
 
 ### Changed

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.16.0 - 2026-02-27
+
+### Added
+
+#### Admin-Controlled Global Feature Flags (Frontend)
+
+- **`available_feature_flags` on `User` type**: New optional field matching the `feature_flags` shape, sourced from admin settings
+- **`useFeatureFlags` — global availability support**: Hook now exposes `userFlags` (raw user preference), `available` (admin-set global availability), and effective booleans (`dates`, `delegation`, `aiAssistant`) that are `true` only when both the user preference and global flag are enabled. Defaults `available` to all `true` when the field is absent for backwards compatibility
+- **`SettingsModal` — disabled toggles with "Coming soon"**: Each feature toggle is disabled when the admin has globally disabled the feature; description text changes to "Coming soon" and the toggle appears greyed out. Toggle direction uses the raw user preference so the stored value is preserved for when the admin re-enables the feature
+
+### Tests
+
+- **`use-feature-flags.test.tsx`**: Added 5 tests — effective false when global disabled, effective false when user disabled, effective true when both true, available defaults to all true, userFlags reflects raw preference
+- **`settings-modal-mcp.test.tsx`**: Updated `useFeatureFlags` mock to include `userFlags` and `available`
+
 ## 0.15.2 - 2026-02-27
 
 ### Fixed

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.16.1 - 2026-03-08
+
+### Changed
+
+#### Pre-Merge Hardening
+
+- **`SettingsModal` — server error messages**: `handleToggle` now surfaces the server's error message (e.g. "One or more features are not currently available") instead of a generic fallback
+- **Modal accessibility**: Added `role="dialog"` and `aria-modal="true"` to `SettingsModal`, `ProfileModal`, `EditItemModal`, `NotesModal`, and `AssignModal`
+
+### Tests
+
+- **`profile-modal.test.tsx`**: 10 tests covering render, close, escape, submit with correct payload, name editing, empty phone sends null, save failure, logout, and success feedback
+
 ## 0.16.0 - 2026-02-27
 
 ### Added

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 0.16.2 - 2026-03-08
+
+### Changed
+
+#### Pre-Merge Bulletproofing
+
+- **`SettingsModal` — version string**: Updated hardcoded version label from `v0.15.0` to `v0.16.2`
+- **`SettingsModal` — MCP URL**: Wrapped URL computation in `useMemo` to avoid recomputation on every render; added SSR guard for `window.location.origin`
+- **`ProfileModal` — error surfacing**: `handleSave` now surfaces the server's error message instead of a generic fallback, consistent with `SettingsModal.handleToggle`
+- **`ProfileModal` — save guard**: Close button, Escape key, and backdrop click are all blocked while a save is in progress to prevent lost feedback
+- **`ProfileModal` — input locking**: Name, email, and phone inputs are disabled with reduced opacity during save
+- **`useModal` hook**: New shared hook that locks body scroll (`document.body.style.overflow = "hidden"`) while any modal is open, restoring the previous value on cleanup; applied to all five modals (`SettingsModal`, `ProfileModal`, `NotesModal`, `EditItemModal`, `AssignModal`)
+- **Focus trapping**: Added `focus-trap-react` (v12) to all five modals via a `<FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>` wrapper — satisfies WCAG 2.1 AA modal focus requirements while allowing backdrop-click-to-close
+- **`User` type**: `feature_flags` is now non-optional (always provided by `UserResource` with defaults merged); `available_feature_flags` remains optional for backwards compatibility
+
+### Tests
+
+- **`profile-modal.test.tsx`**: Updated "shows error message on save failure" to test the generic fallback path (error without message); added backdrop-click test; added cannot-close-while-saving test; added server-error-message surfacing test
+- **`jest.config.ts`**: Added `moduleNameMapper` entry for `focus-trap-react` → jsdom-compatible stub to allow modal tests to run without layout computation
+
 ## 0.16.1 - 2026-03-08
 
 ### Changed

--- a/apps/frontend/jest.config.ts
+++ b/apps/frontend/jest.config.ts
@@ -3,6 +3,7 @@ const config = {
   roots: ["<rootDir>/src"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
+    "^focus-trap-react$": "<rootDir>/src/__mocks__/focus-trap-react.tsx",
   },
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   testPathIgnorePatterns: ["/node_modules/", "/.next/"],

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@serwist/next": "^9.5.0",
         "eslint-config-prettier": "^9.0.0",
+        "focus-trap-react": "^12.0.0",
         "next": "^15.5.9",
         "prettier": "^3.0.0",
         "react": "19.1.0",
@@ -3369,7 +3370,6 @@
       "version": "19.1.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.11.tgz",
       "integrity": "sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ==",
-      "dev": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3378,7 +3378,6 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.8.tgz",
       "integrity": "sha512-xG7xaBMJCpcK0RpN8jDbAACQo54ycO6h4dSSmgv8+fu6ZIAdANkx/WsawASUjVXYfy+J9AbUpRMNNEsXCDfDBQ==",
-      "dev": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -4992,8 +4991,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -6185,6 +6183,31 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="
+    },
+    "node_modules/focus-trap": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.0.0.tgz",
+      "integrity": "sha512-Aa84FOGHs99vVwufDMdq2qgOwXPC2e9U66GcqBhn1/jEHPDhJaP8PYhkIbqG9lhfL5Kddk/567lj46LLHYCRUw==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/focus-trap-react": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-12.0.0.tgz",
+      "integrity": "sha512-bTPk+jbG0Q3zqHjY7KjdmjqMKGKVrKbMwXxHX9+FTYENWxmLryJVoI3ZfStRSJ26uPipl+th9DIPhCyjeEBYdg==",
+      "license": "MIT",
+      "dependencies": {
+        "focus-trap": "^8.0.0",
+        "tabbable": "^6.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -12214,6 +12237,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.17",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@serwist/next": "^9.5.0",
     "eslint-config-prettier": "^9.0.0",
+    "focus-trap-react": "^12.0.0",
     "next": "^15.5.9",
     "prettier": "^3.0.0",
     "react": "19.1.0",

--- a/apps/frontend/src/__mocks__/focus-trap-react.tsx
+++ b/apps/frontend/src/__mocks__/focus-trap-react.tsx
@@ -1,0 +1,7 @@
+import type { ReactNode } from "react";
+
+export function FocusTrap({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}
+
+export default FocusTrap;

--- a/apps/frontend/src/__tests__/profile-modal.test.tsx
+++ b/apps/frontend/src/__tests__/profile-modal.test.tsx
@@ -122,8 +122,9 @@ describe("ProfileModal", () => {
     expect(call.phone).toBeNull();
   });
 
-  test("shows error message on save failure", async () => {
-    (updateUser as jest.Mock).mockRejectedValueOnce(new Error("Server error"));
+  test("shows generic fallback message when error has no message", async () => {
+    // Error() with no message → falls back to the generic string
+    (updateUser as jest.Mock).mockRejectedValueOnce(new Error());
     const user = userEvent.setup();
 
     render(<ProfileModal isOpen={true} onClose={jest.fn()} />);
@@ -156,6 +157,64 @@ describe("ProfileModal", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Profile updated.")).toBeInTheDocument();
+    });
+  });
+
+  test("calls onClose when backdrop is clicked", async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+
+    render(<ProfileModal isOpen={true} onClose={onClose} />);
+
+    // Click the outer backdrop (the dialog element itself)
+    await user.click(screen.getByRole("dialog"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not call onClose while save is in progress", async () => {
+    let resolveUpdate!: () => void;
+    (updateUser as jest.Mock).mockImplementation(
+      () =>
+        new Promise<Record<string, never>>((res) => {
+          resolveUpdate = () => res({});
+        }),
+    );
+
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+
+    render(<ProfileModal isOpen={true} onClose={onClose} />);
+
+    // Start a save that won't resolve yet
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    // Try Escape and close button while saving — both should be no-ops
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Resolve the save to clean up
+    resolveUpdate();
+    await waitFor(() => {
+      expect(screen.getByText("Profile updated.")).toBeInTheDocument();
+    });
+  });
+
+  test("surfaces server error message from API", async () => {
+    (updateUser as jest.Mock).mockRejectedValueOnce(
+      new Error("The email has already been taken."),
+    );
+    const user = userEvent.setup();
+
+    render(<ProfileModal isOpen={true} onClose={jest.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("The email has already been taken."),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/apps/frontend/src/__tests__/profile-modal.test.tsx
+++ b/apps/frontend/src/__tests__/profile-modal.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ProfileModal } from "@/components/ProfileModal";
+import { updateUser } from "@/lib/api";
+
+const logoutMock = jest.fn().mockResolvedValue(undefined);
+const refreshUserMock = jest.fn().mockResolvedValue(undefined);
+
+const mockUser = {
+  id: "u-1",
+  name: "Jane Doe",
+  email: "jane@example.com",
+  phone: "0412345678",
+  notes: null,
+  feature_flags: { dates: false, delegation: false, ai_assistant: false },
+  email_verified_at: "2026-01-01T00:00:00Z",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+jest.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: mockUser,
+    logout: logoutMock,
+    refreshUser: refreshUserMock,
+  }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  updateUser: jest.fn(),
+}));
+
+describe("ProfileModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (updateUser as jest.Mock).mockResolvedValue({});
+  });
+
+  test("does not render when isOpen is false", () => {
+    render(<ProfileModal isOpen={false} onClose={jest.fn()} />);
+    expect(screen.queryByText("Profile")).not.toBeInTheDocument();
+  });
+
+  test("renders user details when open", () => {
+    render(<ProfileModal isOpen={true} onClose={jest.fn()} />);
+
+    expect(screen.getByText("Profile")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Jane Doe")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("jane@example.com")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("0412345678")).toBeInTheDocument();
+    expect(screen.getByText("JD")).toBeInTheDocument();
+  });
+
+  test("calls onClose when close button is clicked", async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+
+    render(<ProfileModal isOpen={true} onClose={onClose} />);
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("calls onClose when Escape is pressed", () => {
+    const onClose = jest.fn();
+    render(<ProfileModal isOpen={true} onClose={onClose} />);
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("submits profile update with correct payload", async () => {
+    const user = userEvent.setup();
+    render(<ProfileModal isOpen={true} onClose={jest.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(updateUser).toHaveBeenCalledTimes(1);
+    });
+
+    const call = (updateUser as jest.Mock).mock.calls[0][0];
+    expect(call.name).toBe("Jane Doe");
+    expect(call.email).toBe("jane@example.com");
+    expect(call.phone).toBe("0412345678");
+
+    expect(refreshUserMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("submits modified name after editing", async () => {
+    const user = userEvent.setup();
+    render(<ProfileModal isOpen={true} onClose={jest.fn()} />);
+
+    const nameInput = screen.getByLabelText("Name");
+    await user.clear(nameInput);
+    await user.type(nameInput, "Jane Smith");
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(updateUser).toHaveBeenCalledTimes(1);
+    });
+
+    const call = (updateUser as jest.Mock).mock.calls[0][0];
+    expect(call.name).toBe("Jane Smith");
+  });
+
+  test("sends null for empty phone field", async () => {
+    const user = userEvent.setup();
+    render(<ProfileModal isOpen={true} onClose={jest.fn()} />);
+
+    const phoneInput = screen.getByLabelText("Phone");
+    await user.clear(phoneInput);
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(updateUser).toHaveBeenCalledTimes(1);
+    });
+
+    const call = (updateUser as jest.Mock).mock.calls[0][0];
+    expect(call.phone).toBeNull();
+  });
+
+  test("shows error message on save failure", async () => {
+    (updateUser as jest.Mock).mockRejectedValueOnce(new Error("Server error"));
+    const user = userEvent.setup();
+
+    render(<ProfileModal isOpen={true} onClose={jest.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to save profile. Please try again."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("calls logout when log out button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ProfileModal isOpen={true} onClose={jest.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Log out" }));
+
+    await waitFor(() => {
+      expect(logoutMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("shows success feedback after save", async () => {
+    const user = userEvent.setup();
+    render(<ProfileModal isOpen={true} onClose={jest.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Profile updated.")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/frontend/src/__tests__/settings-modal-mcp.test.tsx
+++ b/apps/frontend/src/__tests__/settings-modal-mcp.test.tsx
@@ -8,6 +8,8 @@ jest.mock("@/hooks/useFeatureFlags", () => ({
     dates: false,
     delegation: false,
     aiAssistant: true,
+    userFlags: { dates: false, delegation: false, ai_assistant: true },
+    available: { dates: true, delegation: true, ai_assistant: true },
     setFlag: jest.fn(),
     loaded: true,
   }),

--- a/apps/frontend/src/__tests__/use-feature-flags.test.tsx
+++ b/apps/frontend/src/__tests__/use-feature-flags.test.tsx
@@ -27,9 +27,7 @@ function FlagsDisplay() {
       <span data-testid="user-delegation">{String(userFlags.delegation)}</span>
       <span data-testid="user-ai">{String(userFlags.ai_assistant)}</span>
       <span data-testid="avail-dates">{String(available.dates)}</span>
-      <span data-testid="avail-delegation">
-        {String(available.delegation)}
-      </span>
+      <span data-testid="avail-delegation">{String(available.delegation)}</span>
       <span data-testid="avail-ai">{String(available.ai_assistant)}</span>
     </div>
   );

--- a/apps/frontend/src/__tests__/use-feature-flags.test.tsx
+++ b/apps/frontend/src/__tests__/use-feature-flags.test.tsx
@@ -14,6 +14,46 @@ function Harness() {
   );
 }
 
+function FlagsDisplay() {
+  const { dates, delegation, aiAssistant, userFlags, available } =
+    useFeatureFlags();
+
+  return (
+    <div>
+      <span data-testid="eff-dates">{String(dates)}</span>
+      <span data-testid="eff-delegation">{String(delegation)}</span>
+      <span data-testid="eff-ai">{String(aiAssistant)}</span>
+      <span data-testid="user-dates">{String(userFlags.dates)}</span>
+      <span data-testid="user-delegation">{String(userFlags.delegation)}</span>
+      <span data-testid="user-ai">{String(userFlags.ai_assistant)}</span>
+      <span data-testid="avail-dates">{String(available.dates)}</span>
+      <span data-testid="avail-delegation">
+        {String(available.delegation)}
+      </span>
+      <span data-testid="avail-ai">{String(available.ai_assistant)}</span>
+    </div>
+  );
+}
+
+function renderWithAuth(mockUser: User) {
+  return render(
+    <AuthContext.Provider
+      value={{
+        user: mockUser,
+        isAuthenticated: true,
+        isLoading: false,
+        login: jest.fn(),
+        register: jest.fn(),
+        logout: jest.fn(),
+        refreshUser: jest.fn(),
+        updateUser: jest.fn(),
+      }}
+    >
+      <FlagsDisplay />
+    </AuthContext.Provider>,
+  );
+}
+
 describe("useFeatureFlags", () => {
   test("sends only the changed flag key to avoid multi-tab race conditions", async () => {
     const updateUser = jest.fn().mockResolvedValue(undefined);
@@ -60,5 +100,132 @@ describe("useFeatureFlags", () => {
         feature_flags: { dates: true },
       });
     });
+  });
+
+  test("effective false when global disabled but user enabled", () => {
+    const mockUser: User = {
+      id: "user-1",
+      name: "Test",
+      email: "test@example.com",
+      phone: null,
+      notes: null,
+      feature_flags: { dates: true, delegation: true, ai_assistant: true },
+      available_feature_flags: {
+        dates: false,
+        delegation: true,
+        ai_assistant: true,
+      },
+      email_verified_at: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    renderWithAuth(mockUser);
+
+    expect(screen.getByTestId("eff-dates")).toHaveTextContent("false");
+    expect(screen.getByTestId("eff-delegation")).toHaveTextContent("true");
+    expect(screen.getByTestId("eff-ai")).toHaveTextContent("true");
+  });
+
+  test("effective false when user disabled but global enabled", () => {
+    const mockUser: User = {
+      id: "user-1",
+      name: "Test",
+      email: "test@example.com",
+      phone: null,
+      notes: null,
+      feature_flags: { dates: false, delegation: true, ai_assistant: true },
+      available_feature_flags: {
+        dates: true,
+        delegation: true,
+        ai_assistant: true,
+      },
+      email_verified_at: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    renderWithAuth(mockUser);
+
+    expect(screen.getByTestId("eff-dates")).toHaveTextContent("false");
+    expect(screen.getByTestId("eff-delegation")).toHaveTextContent("true");
+  });
+
+  test("effective true only when both user and global are true", () => {
+    const mockUser: User = {
+      id: "user-1",
+      name: "Test",
+      email: "test@example.com",
+      phone: null,
+      notes: null,
+      feature_flags: { dates: true, delegation: true, ai_assistant: true },
+      available_feature_flags: {
+        dates: true,
+        delegation: true,
+        ai_assistant: true,
+      },
+      email_verified_at: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    renderWithAuth(mockUser);
+
+    expect(screen.getByTestId("eff-dates")).toHaveTextContent("true");
+    expect(screen.getByTestId("eff-delegation")).toHaveTextContent("true");
+    expect(screen.getByTestId("eff-ai")).toHaveTextContent("true");
+  });
+
+  test("available defaults to all true when field missing", () => {
+    const mockUser: User = {
+      id: "user-1",
+      name: "Test",
+      email: "test@example.com",
+      phone: null,
+      notes: null,
+      feature_flags: { dates: true, delegation: true, ai_assistant: true },
+      // no available_feature_flags
+      email_verified_at: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    renderWithAuth(mockUser);
+
+    expect(screen.getByTestId("avail-dates")).toHaveTextContent("true");
+    expect(screen.getByTestId("avail-delegation")).toHaveTextContent("true");
+    expect(screen.getByTestId("avail-ai")).toHaveTextContent("true");
+    // Effective should also be true since both user and available (defaulted) are true
+    expect(screen.getByTestId("eff-dates")).toHaveTextContent("true");
+  });
+
+  test("userFlags reflects raw preference regardless of availability", () => {
+    const mockUser: User = {
+      id: "user-1",
+      name: "Test",
+      email: "test@example.com",
+      phone: null,
+      notes: null,
+      feature_flags: { dates: true, delegation: false, ai_assistant: true },
+      available_feature_flags: {
+        dates: false,
+        delegation: false,
+        ai_assistant: false,
+      },
+      email_verified_at: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    renderWithAuth(mockUser);
+
+    // userFlags are raw, unaffected by availability
+    expect(screen.getByTestId("user-dates")).toHaveTextContent("true");
+    expect(screen.getByTestId("user-delegation")).toHaveTextContent("false");
+    expect(screen.getByTestId("user-ai")).toHaveTextContent("true");
+    // Effective should be false since all are globally disabled
+    expect(screen.getByTestId("eff-dates")).toHaveTextContent("false");
+    expect(screen.getByTestId("eff-delegation")).toHaveTextContent("false");
+    expect(screen.getByTestId("eff-ai")).toHaveTextContent("false");
   });
 });

--- a/apps/frontend/src/components/AssignModal.tsx
+++ b/apps/frontend/src/components/AssignModal.tsx
@@ -2,7 +2,9 @@
 
 import type { UserLookup } from "@/types";
 import { useState, useEffect, useCallback } from "react";
+import { FocusTrap } from "focus-trap-react";
 import { lookupUsers, discoverUser, toggleFavourite } from "@/lib/api";
+import { useModal } from "@/hooks/useModal";
 
 type Props = {
   isOpen: boolean;
@@ -21,6 +23,7 @@ export function AssignModal({
   favourites = [],
   onFavouriteToggled,
 }: Props) {
+  useModal(isOpen);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<UserLookup[]>([]);
   const [discoveredUser, setDiscoveredUser] = useState<UserLookup | null>(null);
@@ -113,200 +116,204 @@ export function AssignModal({
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 animate-fade-in"
       onClick={onClose}
     >
-      <div
-        className="w-full max-w-md mx-4 bg-white rounded-lg shadow-xl animate-scale-in"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-slate-200">
-          <h2 className="text-lg font-semibold text-[var(--navy)]">
-            Assign Task
-          </h2>
-          <button
-            onClick={onClose}
-            className="p-1 rounded-md hover:bg-slate-100 transition-colors"
-            aria-label="Close"
-          >
-            <svg
-              viewBox="0 0 24 24"
-              width="20"
-              height="20"
-              fill="none"
-              stroke="currentColor"
-              className="text-slate-500"
+      <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
+        <div
+          className="w-full max-w-md mx-4 bg-white rounded-lg shadow-xl animate-scale-in"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between p-4 border-b border-slate-200">
+            <h2 className="text-lg font-semibold text-[var(--navy)]">
+              Assign Task
+            </h2>
+            <button
+              onClick={onClose}
+              className="p-1 rounded-md hover:bg-slate-100 transition-colors"
+              aria-label="Close"
             >
-              <path
-                d="M18 6 6 18M6 6l12 12"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
-
-        {/* Search input */}
-        <div className="p-4">
-          <input
-            type="text"
-            placeholder="Search by email or phone..."
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm transition-all duration-200 focus:border-[var(--blue)] focus:ring-2 focus:ring-[var(--blue)]/20 focus:outline-none"
-            autoFocus
-          />
-          <p className="mt-2 text-xs text-slate-500">
-            Enter email or last 9 digits of phone number
-          </p>
-        </div>
-
-        {/* Current assignee */}
-        {currentAssignee && (
-          <div className="px-4 pb-2">
-            <div className="flex items-center justify-between p-3 bg-slate-50 rounded-md">
-              <div>
-                <div className="text-sm font-medium text-slate-700">
-                  {currentAssignee.name}
-                </div>
-                <div className="text-xs text-slate-500">
-                  {currentAssignee.email_masked}
-                </div>
-              </div>
-              <button
-                onClick={() => onSelect(null)}
-                className="px-3 py-1 text-sm text-red-600 bg-red-50 rounded-md hover:bg-red-100 transition-colors"
+              <svg
+                viewBox="0 0 24 24"
+                width="20"
+                height="20"
+                fill="none"
+                stroke="currentColor"
+                className="text-slate-500"
               >
-                Remove
-              </button>
-            </div>
+                <path
+                  d="M18 6 6 18M6 6l12 12"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
           </div>
-        )}
 
-        {/* Favourites quick-pick (shown when no active search) */}
-        {showFavourites && (
-          <div className="px-4 pb-2">
-            <p className="text-xs font-medium text-slate-500 mb-2">
-              Favourites
+          {/* Search input */}
+          <div className="p-4">
+            <input
+              type="text"
+              placeholder="Search by email or phone..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm transition-all duration-200 focus:border-[var(--blue)] focus:ring-2 focus:ring-[var(--blue)]/20 focus:outline-none"
+              autoFocus
+            />
+            <p className="mt-2 text-xs text-slate-500">
+              Enter email or last 9 digits of phone number
             </p>
-            <div className="flex flex-wrap gap-2">
-              {favourites.map((fav) => (
-                <button
-                  key={fav.id}
-                  onClick={() => {
-                    onSelect(fav);
-                    onClose();
-                  }}
-                  className="flex items-center gap-1.5 px-3 py-1.5 bg-amber-50 border border-amber-200 rounded-full text-sm text-slate-700 hover:bg-amber-100 transition-colors"
-                >
-                  <span className="text-amber-500">★</span>
-                  {fav.name}
-                </button>
-              ))}
-            </div>
           </div>
-        )}
 
-        {/* Results */}
-        <div className="px-4 pb-4 max-h-64 overflow-y-auto">
-          {loading && (
-            <div className="py-4 text-center text-sm text-slate-500">
-              Searching...
+          {/* Current assignee */}
+          {currentAssignee && (
+            <div className="px-4 pb-2">
+              <div className="flex items-center justify-between p-3 bg-slate-50 rounded-md">
+                <div>
+                  <div className="text-sm font-medium text-slate-700">
+                    {currentAssignee.name}
+                  </div>
+                  <div className="text-xs text-slate-500">
+                    {currentAssignee.email_masked}
+                  </div>
+                </div>
+                <button
+                  onClick={() => onSelect(null)}
+                  className="px-3 py-1 text-sm text-red-600 bg-red-50 rounded-md hover:bg-red-100 transition-colors"
+                >
+                  Remove
+                </button>
+              </div>
             </div>
           )}
 
-          {error && (
-            <div className="py-4 text-center text-sm text-red-500">{error}</div>
+          {/* Favourites quick-pick (shown when no active search) */}
+          {showFavourites && (
+            <div className="px-4 pb-2">
+              <p className="text-xs font-medium text-slate-500 mb-2">
+                Favourites
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {favourites.map((fav) => (
+                  <button
+                    key={fav.id}
+                    onClick={() => {
+                      onSelect(fav);
+                      onClose();
+                    }}
+                    className="flex items-center gap-1.5 px-3 py-1.5 bg-amber-50 border border-amber-200 rounded-full text-sm text-slate-700 hover:bg-amber-100 transition-colors"
+                  >
+                    <span className="text-amber-500">★</span>
+                    {fav.name}
+                  </button>
+                ))}
+              </div>
+            </div>
           )}
 
-          {!loading &&
-            !error &&
-            results.length === 0 &&
-            !discoveredUser &&
-            query.length >= 3 && (
+          {/* Results */}
+          <div className="px-4 pb-4 max-h-64 overflow-y-auto">
+            {loading && (
               <div className="py-4 text-center text-sm text-slate-500">
-                No users found
+                Searching...
               </div>
             )}
 
-          {/* Connected users — direct selection */}
-          {!loading && results.length > 0 && (
-            <div className="space-y-2">
-              {results.map((resultUser) => (
+            {error && (
+              <div className="py-4 text-center text-sm text-red-500">
+                {error}
+              </div>
+            )}
+
+            {!loading &&
+              !error &&
+              results.length === 0 &&
+              !discoveredUser &&
+              query.length >= 3 && (
+                <div className="py-4 text-center text-sm text-slate-500">
+                  No users found
+                </div>
+              )}
+
+            {/* Connected users — direct selection */}
+            {!loading && results.length > 0 && (
+              <div className="space-y-2">
+                {results.map((resultUser) => (
+                  <button
+                    key={resultUser.id}
+                    onClick={() => {
+                      onSelect(resultUser);
+                      onClose();
+                    }}
+                    className="w-full flex items-center gap-3 p-3 rounded-md hover:bg-slate-50 transition-colors text-left"
+                  >
+                    <div className="w-10 h-10 rounded-full bg-[var(--blue)] flex items-center justify-center text-white font-medium">
+                      {resultUser.name.charAt(0).toUpperCase()}
+                    </div>
+                    <div className="flex-1">
+                      <div className="flex items-center gap-1">
+                        <span className="text-sm font-medium text-slate-700">
+                          {resultUser.name}
+                        </span>
+                        {isFavourite(resultUser.id) && (
+                          <span className="text-amber-500 text-xs">★</span>
+                        )}
+                      </div>
+                      <div className="text-xs text-slate-500">
+                        {resultUser.email_masked}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      aria-label={
+                        isFavourite(resultUser.id)
+                          ? "Remove from favourites"
+                          : "Add to favourites"
+                      }
+                      disabled={togglingFavId === resultUser.id}
+                      onClick={(e) => handleToggleFavourite(e, resultUser.id)}
+                      className="p-1 rounded-md hover:bg-slate-100 transition-colors disabled:opacity-50"
+                    >
+                      <span
+                        className={`text-lg ${isFavourite(resultUser.id) ? "text-amber-400" : "text-slate-300"}`}
+                      >
+                        ★
+                      </span>
+                    </button>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* Discovered user — not yet connected, but backend auto-connects on assignment */}
+            {!loading && discoveredUser && (
+              <div className="space-y-2">
+                <p className="text-xs text-slate-500">
+                  User found — a connection will be created automatically
+                </p>
                 <button
-                  key={resultUser.id}
                   onClick={() => {
-                    onSelect(resultUser);
+                    onSelect(discoveredUser);
                     onClose();
                   }}
-                  className="w-full flex items-center gap-3 p-3 rounded-md hover:bg-slate-50 transition-colors text-left"
+                  className="w-full flex items-center gap-3 p-3 rounded-md bg-amber-50 border border-amber-200 hover:bg-amber-100 transition-colors text-left"
                 >
-                  <div className="w-10 h-10 rounded-full bg-[var(--blue)] flex items-center justify-center text-white font-medium">
-                    {resultUser.name.charAt(0).toUpperCase()}
+                  <div className="w-10 h-10 rounded-full bg-amber-500 flex items-center justify-center text-white font-medium">
+                    {discoveredUser.name.charAt(0).toUpperCase()}
                   </div>
-                  <div className="flex-1">
-                    <div className="flex items-center gap-1">
-                      <span className="text-sm font-medium text-slate-700">
-                        {resultUser.name}
-                      </span>
-                      {isFavourite(resultUser.id) && (
-                        <span className="text-amber-500 text-xs">★</span>
-                      )}
+                  <div>
+                    <div className="text-sm font-medium text-slate-700">
+                      {discoveredUser.name}
                     </div>
                     <div className="text-xs text-slate-500">
-                      {resultUser.email_masked}
+                      {discoveredUser.email_masked}
                     </div>
                   </div>
-                  <button
-                    type="button"
-                    aria-label={
-                      isFavourite(resultUser.id)
-                        ? "Remove from favourites"
-                        : "Add to favourites"
-                    }
-                    disabled={togglingFavId === resultUser.id}
-                    onClick={(e) => handleToggleFavourite(e, resultUser.id)}
-                    className="p-1 rounded-md hover:bg-slate-100 transition-colors disabled:opacity-50"
-                  >
-                    <span
-                      className={`text-lg ${isFavourite(resultUser.id) ? "text-amber-400" : "text-slate-300"}`}
-                    >
-                      ★
-                    </span>
-                  </button>
                 </button>
-              ))}
-            </div>
-          )}
-
-          {/* Discovered user — not yet connected, but backend auto-connects on assignment */}
-          {!loading && discoveredUser && (
-            <div className="space-y-2">
-              <p className="text-xs text-slate-500">
-                User found — a connection will be created automatically
-              </p>
-              <button
-                onClick={() => {
-                  onSelect(discoveredUser);
-                  onClose();
-                }}
-                className="w-full flex items-center gap-3 p-3 rounded-md bg-amber-50 border border-amber-200 hover:bg-amber-100 transition-colors text-left"
-              >
-                <div className="w-10 h-10 rounded-full bg-amber-500 flex items-center justify-center text-white font-medium">
-                  {discoveredUser.name.charAt(0).toUpperCase()}
-                </div>
-                <div>
-                  <div className="text-sm font-medium text-slate-700">
-                    {discoveredUser.name}
-                  </div>
-                  <div className="text-xs text-slate-500">
-                    {discoveredUser.email_masked}
-                  </div>
-                </div>
-              </button>
-            </div>
-          )}
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      </FocusTrap>
     </div>
   );
 }

--- a/apps/frontend/src/components/AssignModal.tsx
+++ b/apps/frontend/src/components/AssignModal.tsx
@@ -108,6 +108,8 @@ export function AssignModal({
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 animate-fade-in"
       onClick={onClose}
     >

--- a/apps/frontend/src/components/EditItemModal.tsx
+++ b/apps/frontend/src/components/EditItemModal.tsx
@@ -86,6 +86,8 @@ export function EditItemModal({
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm animate-fade-in"
       onClick={handleBackdropClick}
     >

--- a/apps/frontend/src/components/EditItemModal.tsx
+++ b/apps/frontend/src/components/EditItemModal.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
+import { FocusTrap } from "focus-trap-react";
 import type { Item, Project, UserLookup } from "@/types";
 import { ItemForm } from "./ItemForm";
+import { useModal } from "@/hooks/useModal";
 
 interface EditItemModalProps {
   isOpen: boolean;
@@ -41,6 +43,7 @@ export function EditItemModal({
   onFavouriteToggled,
 }: EditItemModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
+  useModal(isOpen);
 
   // Handle submission - call onSubmit then close
   const handleSubmit = useCallback(
@@ -91,52 +94,54 @@ export function EditItemModal({
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm animate-fade-in"
       onClick={handleBackdropClick}
     >
-      <div
-        ref={modalRef}
-        className="w-[90vw] max-w-2xl max-h-[90vh] overflow-y-auto rounded-lg bg-white p-6 shadow-xl animate-scale-in"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold text-gray-900">
-            {item ? "Edit Task" : "New Task"}
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-full p-2 hover:bg-gray-100 transition-colors"
-            aria-label="Close"
-          >
-            <svg
-              viewBox="0 0 24 24"
-              width="20"
-              height="20"
-              fill="none"
-              stroke="currentColor"
-              className="text-gray-500"
+      <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
+        <div
+          ref={modalRef}
+          className="w-[90vw] max-w-2xl max-h-[90vh] overflow-y-auto rounded-lg bg-white p-6 shadow-xl animate-scale-in"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-gray-900">
+              {item ? "Edit Task" : "New Task"}
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-full p-2 hover:bg-gray-100 transition-colors"
+              aria-label="Close"
             >
-              <path
-                d="M18 6 6 18M6 6l12 12"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
+              <svg
+                viewBox="0 0 24 24"
+                width="20"
+                height="20"
+                fill="none"
+                stroke="currentColor"
+                className="text-gray-500"
+              >
+                <path
+                  d="M18 6 6 18M6 6l12 12"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
 
-        {/* ItemForm */}
-        <ItemForm
-          initial={item ?? undefined}
-          onSubmit={handleSubmit}
-          onCancel={onClose}
-          submitLabel={item ? "Save" : "Add"}
-          projects={projects}
-          onCreateProject={onCreateProject}
-          showAssignment={showAssignment}
-          favourites={favourites}
-          onFavouriteToggled={onFavouriteToggled}
-        />
-      </div>
+          {/* ItemForm */}
+          <ItemForm
+            initial={item ?? undefined}
+            onSubmit={handleSubmit}
+            onCancel={onClose}
+            submitLabel={item ? "Save" : "Add"}
+            projects={projects}
+            onCreateProject={onCreateProject}
+            showAssignment={showAssignment}
+            favourites={favourites}
+            onFavouriteToggled={onFavouriteToggled}
+          />
+        </div>
+      </FocusTrap>
     </div>
   );
 }

--- a/apps/frontend/src/components/NotesModal.tsx
+++ b/apps/frontend/src/components/NotesModal.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { FocusTrap } from "focus-trap-react";
 import { fetchUser, updateUser } from "@/lib/api";
+import { useModal } from "@/hooks/useModal";
 
 interface NotesModalProps {
   isOpen: boolean;
@@ -15,6 +17,7 @@ const MAX_CHARS = 10_000;
  */
 export function NotesModal({ isOpen, onClose }: NotesModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
+  useModal(isOpen);
   const [notes, setNotes] = useState("");
   const [originalNotes, setOriginalNotes] = useState("");
   const [saving, setSaving] = useState(false);
@@ -100,58 +103,62 @@ export function NotesModal({ isOpen, onClose }: NotesModalProps) {
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm animate-fade-in"
       onClick={handleBackdropClick}
     >
-      <div
-        ref={modalRef}
-        className="w-[90vw] max-w-2xl max-h-[90vh] overflow-y-auto rounded-lg bg-white p-6 shadow-xl animate-scale-in"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold text-gray-900">Notes</h2>
-          <div className="flex items-center gap-3">
-            {/* Save indicator */}
-            {saving && <span className="text-xs text-gray-400">Saving...</span>}
-            {saved && !saving && (
-              <span className="text-xs text-green-500">Saved</span>
-            )}
-            <button
-              type="button"
-              onClick={handleClose}
-              className="rounded-full p-2 hover:bg-gray-100 transition-colors"
-              aria-label="Close"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                width="20"
-                height="20"
-                fill="none"
-                stroke="currentColor"
-                className="text-gray-500"
+      <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
+        <div
+          ref={modalRef}
+          className="w-[90vw] max-w-2xl max-h-[90vh] overflow-y-auto rounded-lg bg-white p-6 shadow-xl animate-scale-in"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-gray-900">Notes</h2>
+            <div className="flex items-center gap-3">
+              {/* Save indicator */}
+              {saving && (
+                <span className="text-xs text-gray-400">Saving...</span>
+              )}
+              {saved && !saving && (
+                <span className="text-xs text-green-500">Saved</span>
+              )}
+              <button
+                type="button"
+                onClick={handleClose}
+                className="rounded-full p-2 hover:bg-gray-100 transition-colors"
+                aria-label="Close"
               >
-                <path
-                  d="M18 6 6 18M6 6l12 12"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </button>
+                <svg
+                  viewBox="0 0 24 24"
+                  width="20"
+                  height="20"
+                  fill="none"
+                  stroke="currentColor"
+                  className="text-gray-500"
+                >
+                  <path
+                    d="M18 6 6 18M6 6l12 12"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          {/* Textarea */}
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value.slice(0, MAX_CHARS))}
+            onBlur={() => saveNotes(notes)}
+            placeholder="Jot down anything..."
+            className="w-full min-h-[400px] max-h-[80vh] resize-y rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-300 focus:outline-none focus:ring-1 focus:ring-blue-300"
+          />
+
+          {/* Character counter */}
+          <div className="mt-2 text-right text-xs text-gray-400">
+            {notes.length.toLocaleString()} / {MAX_CHARS.toLocaleString()}
           </div>
         </div>
-
-        {/* Textarea */}
-        <textarea
-          value={notes}
-          onChange={(e) => setNotes(e.target.value.slice(0, MAX_CHARS))}
-          onBlur={() => saveNotes(notes)}
-          placeholder="Jot down anything..."
-          className="w-full min-h-[400px] max-h-[80vh] resize-y rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-300 focus:outline-none focus:ring-1 focus:ring-blue-300"
-        />
-
-        {/* Character counter */}
-        <div className="mt-2 text-right text-xs text-gray-400">
-          {notes.length.toLocaleString()} / {MAX_CHARS.toLocaleString()}
-        </div>
-      </div>
+      </FocusTrap>
     </div>
   );
 }

--- a/apps/frontend/src/components/NotesModal.tsx
+++ b/apps/frontend/src/components/NotesModal.tsx
@@ -95,6 +95,8 @@ export function NotesModal({ isOpen, onClose }: NotesModalProps) {
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm animate-fade-in"
       onClick={handleBackdropClick}
     >

--- a/apps/frontend/src/components/ProfileModal.tsx
+++ b/apps/frontend/src/components/ProfileModal.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { updateUser } from "@/lib/api";
+
+interface ProfileModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const { user, logout, refreshUser } = useAuth();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  // Sync form fields when the modal opens
+  useEffect(() => {
+    if (isOpen && user) {
+      setName(user.name);
+      setEmail(user.email);
+      setPhone(user.phone ?? "");
+      setError(null);
+      setSuccess(false);
+    }
+  }, [isOpen, user]);
+
+  // Close on escape key
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }
+  }, [isOpen, onClose]);
+
+  function handleBackdropClick(e: React.MouseEvent) {
+    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+      onClose();
+    }
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (saving) return;
+
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      await updateUser({
+        name: name.trim(),
+        email: email.trim(),
+        phone: phone.trim() || null,
+      });
+      await refreshUser();
+      setSuccess(true);
+      setTimeout(() => setSuccess(false), 2000);
+    } catch (err) {
+      console.error("Failed to update profile:", err);
+      setError("Failed to save profile. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleLogout() {
+    await logout();
+  }
+
+  if (!isOpen || !user) return null;
+
+  const initials = user.name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm animate-fade-in p-4"
+      onClick={handleBackdropClick}
+    >
+      <div
+        ref={modalRef}
+        className="w-full max-w-md max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-6 shadow-xl animate-slide-in-up"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-lg font-semibold text-gray-900">Profile</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-2 hover:bg-gray-100 transition-colors"
+            aria-label="Close"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              width="20"
+              height="20"
+              fill="none"
+              stroke="currentColor"
+              className="text-gray-500"
+            >
+              <path
+                d="M18 6 6 18M6 6l12 12"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Avatar */}
+        <div className="flex justify-center mb-6">
+          <div className="h-16 w-16 rounded-full bg-[var(--blue)] flex items-center justify-center text-white text-xl font-semibold">
+            {initials}
+          </div>
+        </div>
+
+        {/* Feedback */}
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md text-sm text-red-700">
+            {error}
+          </div>
+        )}
+        {success && (
+          <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-md text-sm text-green-700">
+            Profile updated.
+          </div>
+        )}
+
+        {/* Form */}
+        <form onSubmit={handleSave} className="space-y-4">
+          <div>
+            <label
+              htmlFor="profile-name"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Name
+            </label>
+            <input
+              id="profile-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="profile-email"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Email
+            </label>
+            <input
+              id="profile-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="profile-phone"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Phone
+            </label>
+            <input
+              id="profile-phone"
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              placeholder="Optional"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={saving || !name.trim() || !email.trim()}
+            className="w-full rounded-md bg-[var(--blue)] px-4 py-2.5 text-sm font-medium text-white hover:bg-[var(--blue-600)] disabled:opacity-50 transition-colors"
+          >
+            {saving ? "Saving..." : "Save changes"}
+          </button>
+        </form>
+
+        {/* Logout */}
+        <div className="mt-6 pt-4 border-t border-gray-100">
+          <button
+            type="button"
+            onClick={() => void handleLogout()}
+            className="w-full rounded-md border border-red-200 px-4 py-2.5 text-sm font-medium text-red-700 hover:bg-red-50 transition-colors"
+          >
+            Log out
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/ProfileModal.tsx
+++ b/apps/frontend/src/components/ProfileModal.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { FocusTrap } from "focus-trap-react";
 import { useAuth } from "@/contexts/AuthContext";
+import { useModal } from "@/hooks/useModal";
 import { updateUser } from "@/lib/api";
 
 interface ProfileModalProps {
@@ -12,6 +14,7 @@ interface ProfileModalProps {
 export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const { user, logout, refreshUser } = useAuth();
+  useModal(isOpen);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
@@ -30,22 +33,28 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
     }
   }, [isOpen, user]);
 
-  // Close on escape key
+  // Close on escape key — blocked while saving
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape" && !saving) onClose();
     }
 
     if (isOpen) {
       document.addEventListener("keydown", handleKeyDown);
       return () => document.removeEventListener("keydown", handleKeyDown);
     }
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose, saving]);
 
   function handleBackdropClick(e: React.MouseEvent) {
+    if (saving) return;
     if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
       onClose();
     }
+  }
+
+  function handleCloseClick() {
+    if (saving) return;
+    onClose();
   }
 
   async function handleSave(e: React.FormEvent) {
@@ -67,7 +76,11 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
       setTimeout(() => setSuccess(false), 2000);
     } catch (err) {
       console.error("Failed to update profile:", err);
-      setError("Failed to save profile. Please try again.");
+      const message =
+        err instanceof Error && err.message
+          ? err.message
+          : "Failed to save profile. Please try again.";
+      setError(message);
     } finally {
       setSaving(false);
     }
@@ -93,129 +106,135 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm animate-fade-in p-4"
       onClick={handleBackdropClick}
     >
-      <div
-        ref={modalRef}
-        className="w-full max-w-md max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-6 shadow-xl animate-slide-in-up"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between mb-6">
-          <h2 className="text-lg font-semibold text-gray-900">Profile</h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-full p-2 hover:bg-gray-100 transition-colors"
-            aria-label="Close"
-          >
-            <svg
-              viewBox="0 0 24 24"
-              width="20"
-              height="20"
-              fill="none"
-              stroke="currentColor"
-              className="text-gray-500"
+      <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
+        <div
+          ref={modalRef}
+          className="w-full max-w-md max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-6 shadow-xl animate-slide-in-up"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between mb-6">
+            <h2 className="text-lg font-semibold text-gray-900">Profile</h2>
+            <button
+              type="button"
+              onClick={handleCloseClick}
+              disabled={saving}
+              className="rounded-full p-2 hover:bg-gray-100 transition-colors disabled:opacity-50"
+              aria-label="Close"
             >
-              <path
-                d="M18 6 6 18M6 6l12 12"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
+              <svg
+                viewBox="0 0 24 24"
+                width="20"
+                height="20"
+                fill="none"
+                stroke="currentColor"
+                className="text-gray-500"
+              >
+                <path
+                  d="M18 6 6 18M6 6l12 12"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+
+          {/* Avatar */}
+          <div className="flex justify-center mb-6">
+            <div className="h-16 w-16 rounded-full bg-[var(--blue)] flex items-center justify-center text-white text-xl font-semibold">
+              {initials}
+            </div>
+          </div>
+
+          {/* Feedback */}
+          {error && (
+            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md text-sm text-red-700">
+              {error}
+            </div>
+          )}
+          {success && (
+            <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-md text-sm text-green-700">
+              Profile updated.
+            </div>
+          )}
+
+          {/* Form */}
+          <form onSubmit={handleSave} className="space-y-4">
+            <div>
+              <label
+                htmlFor="profile-name"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Name
+              </label>
+              <input
+                id="profile-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+                disabled={saving}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50"
               />
-            </svg>
-          </button>
-        </div>
+            </div>
 
-        {/* Avatar */}
-        <div className="flex justify-center mb-6">
-          <div className="h-16 w-16 rounded-full bg-[var(--blue)] flex items-center justify-center text-white text-xl font-semibold">
-            {initials}
-          </div>
-        </div>
+            <div>
+              <label
+                htmlFor="profile-email"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Email
+              </label>
+              <input
+                id="profile-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                disabled={saving}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50"
+              />
+            </div>
 
-        {/* Feedback */}
-        {error && (
-          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md text-sm text-red-700">
-            {error}
-          </div>
-        )}
-        {success && (
-          <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-md text-sm text-green-700">
-            Profile updated.
-          </div>
-        )}
+            <div>
+              <label
+                htmlFor="profile-phone"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Phone
+              </label>
+              <input
+                id="profile-phone"
+                type="tel"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                placeholder="Optional"
+                disabled={saving}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50"
+              />
+            </div>
 
-        {/* Form */}
-        <form onSubmit={handleSave} className="space-y-4">
-          <div>
-            <label
-              htmlFor="profile-name"
-              className="block text-sm font-medium text-gray-700 mb-1"
+            <button
+              type="submit"
+              disabled={saving || !name.trim() || !email.trim()}
+              className="w-full rounded-md bg-[var(--blue)] px-4 py-2.5 text-sm font-medium text-white hover:bg-[var(--blue-600)] disabled:opacity-50 transition-colors"
             >
-              Name
-            </label>
-            <input
-              id="profile-name"
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              required
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            />
-          </div>
+              {saving ? "Saving..." : "Save changes"}
+            </button>
+          </form>
 
-          <div>
-            <label
-              htmlFor="profile-email"
-              className="block text-sm font-medium text-gray-700 mb-1"
+          {/* Logout */}
+          <div className="mt-6 pt-4 border-t border-gray-100">
+            <button
+              type="button"
+              onClick={() => void handleLogout()}
+              className="w-full rounded-md border border-red-200 px-4 py-2.5 text-sm font-medium text-red-700 hover:bg-red-50 transition-colors"
             >
-              Email
-            </label>
-            <input
-              id="profile-email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            />
+              Log out
+            </button>
           </div>
-
-          <div>
-            <label
-              htmlFor="profile-phone"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              Phone
-            </label>
-            <input
-              id="profile-phone"
-              type="tel"
-              value={phone}
-              onChange={(e) => setPhone(e.target.value)}
-              placeholder="Optional"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            />
-          </div>
-
-          <button
-            type="submit"
-            disabled={saving || !name.trim() || !email.trim()}
-            className="w-full rounded-md bg-[var(--blue)] px-4 py-2.5 text-sm font-medium text-white hover:bg-[var(--blue-600)] disabled:opacity-50 transition-colors"
-          >
-            {saving ? "Saving..." : "Save changes"}
-          </button>
-        </form>
-
-        {/* Logout */}
-        <div className="mt-6 pt-4 border-t border-gray-100">
-          <button
-            type="button"
-            onClick={() => void handleLogout()}
-            className="w-full rounded-md border border-red-200 px-4 py-2.5 text-sm font-medium text-red-700 hover:bg-red-50 transition-colors"
-          >
-            Log out
-          </button>
         </div>
-      </div>
+      </FocusTrap>
     </div>
   );
 }

--- a/apps/frontend/src/components/ProfileModal.tsx
+++ b/apps/frontend/src/components/ProfileModal.tsx
@@ -88,6 +88,8 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm animate-fade-in p-4"
       onClick={handleBackdropClick}
     >

--- a/apps/frontend/src/components/SettingsModal.tsx
+++ b/apps/frontend/src/components/SettingsModal.tsx
@@ -16,7 +16,8 @@ interface SettingsModalProps {
  */
 export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
-  const { dates, delegation, aiAssistant, setFlag } = useFeatureFlags();
+  const { dates, delegation, aiAssistant, userFlags, available, setFlag } =
+    useFeatureFlags();
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [mcpTokens, setMcpTokens] = useState<McpToken[]>([]);
@@ -204,14 +205,16 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
               <div className="flex items-center gap-3">
                 <button
                   type="button"
-                  onClick={() => handleToggle("dates", !dates)}
-                  disabled={saving}
+                  onClick={() =>
+                    handleToggle("dates", !userFlags.dates)
+                  }
+                  disabled={saving || !available.dates}
                   className={`
                     relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full
                     border-2 border-transparent transition-colors duration-200 ease-in-out
                     focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
-                    ${dates ? "bg-blue-600" : "bg-gray-200"}
-                    ${saving ? "opacity-50 cursor-not-allowed" : ""}
+                    ${userFlags.dates && available.dates ? "bg-blue-600" : "bg-gray-200"}
+                    ${saving || !available.dates ? "opacity-50 cursor-not-allowed" : ""}
                   `}
                   role="switch"
                   aria-checked={dates}
@@ -221,7 +224,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                     className={`
                       pointer-events-none inline-block h-5 w-5 transform rounded-full
                       bg-white shadow ring-0 transition duration-200 ease-in-out
-                      ${dates ? "translate-x-5" : "translate-x-0"}
+                      ${userFlags.dates && available.dates ? "translate-x-5" : "translate-x-0"}
                     `}
                   />
                 </button>
@@ -230,7 +233,9 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                     Dates &amp; Scheduling
                   </span>
                   <span className="text-xs text-gray-500">
-                    Due dates, scheduled dates, and repeating tasks
+                    {available.dates
+                      ? "Due dates, scheduled dates, and repeating tasks"
+                      : "Coming soon"}
                   </span>
                 </div>
               </div>
@@ -239,14 +244,16 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
               <div className="flex items-center gap-3">
                 <button
                   type="button"
-                  onClick={() => handleToggle("delegation", !delegation)}
-                  disabled={saving}
+                  onClick={() =>
+                    handleToggle("delegation", !userFlags.delegation)
+                  }
+                  disabled={saving || !available.delegation}
                   className={`
                     relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full
                     border-2 border-transparent transition-colors duration-200 ease-in-out
                     focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
-                    ${delegation ? "bg-blue-600" : "bg-gray-200"}
-                    ${saving ? "opacity-50 cursor-not-allowed" : ""}
+                    ${userFlags.delegation && available.delegation ? "bg-blue-600" : "bg-gray-200"}
+                    ${saving || !available.delegation ? "opacity-50 cursor-not-allowed" : ""}
                   `}
                   role="switch"
                   aria-checked={delegation}
@@ -256,7 +263,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                     className={`
                       pointer-events-none inline-block h-5 w-5 transform rounded-full
                       bg-white shadow ring-0 transition duration-200 ease-in-out
-                      ${delegation ? "translate-x-5" : "translate-x-0"}
+                      ${userFlags.delegation && available.delegation ? "translate-x-5" : "translate-x-0"}
                     `}
                   />
                 </button>
@@ -265,7 +272,9 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                     Task Delegation
                   </span>
                   <span className="text-xs text-gray-500">
-                    Assign tasks to other users
+                    {available.delegation
+                      ? "Assign tasks to other users"
+                      : "Coming soon"}
                   </span>
                 </div>
               </div>
@@ -274,14 +283,16 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
               <div className="flex items-center gap-3">
                 <button
                   type="button"
-                  onClick={() => handleToggle("ai_assistant", !aiAssistant)}
-                  disabled={saving}
+                  onClick={() =>
+                    handleToggle("ai_assistant", !userFlags.ai_assistant)
+                  }
+                  disabled={saving || !available.ai_assistant}
                   className={`
                     relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full
                     border-2 border-transparent transition-colors duration-200 ease-in-out
                     focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
-                    ${aiAssistant ? "bg-blue-600" : "bg-gray-200"}
-                    ${saving ? "opacity-50 cursor-not-allowed" : ""}
+                    ${userFlags.ai_assistant && available.ai_assistant ? "bg-blue-600" : "bg-gray-200"}
+                    ${saving || !available.ai_assistant ? "opacity-50 cursor-not-allowed" : ""}
                   `}
                   role="switch"
                   aria-checked={aiAssistant}
@@ -291,7 +302,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                     className={`
                       pointer-events-none inline-block h-5 w-5 transform rounded-full
                       bg-white shadow ring-0 transition duration-200 ease-in-out
-                      ${aiAssistant ? "translate-x-5" : "translate-x-0"}
+                      ${userFlags.ai_assistant && available.ai_assistant ? "translate-x-5" : "translate-x-0"}
                     `}
                   />
                 </button>
@@ -300,7 +311,9 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                     AI Assistant (MCP)
                   </span>
                   <span className="text-xs text-gray-500">
-                    Enable MCP token management for agent integrations
+                    {available.ai_assistant
+                      ? "Enable MCP token management for agent integrations"
+                      : "Coming soon"}
                   </span>
                 </div>
               </div>

--- a/apps/frontend/src/components/SettingsModal.tsx
+++ b/apps/frontend/src/components/SettingsModal.tsx
@@ -205,9 +205,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
               <div className="flex items-center gap-3">
                 <button
                   type="button"
-                  onClick={() =>
-                    handleToggle("dates", !userFlags.dates)
-                  }
+                  onClick={() => handleToggle("dates", !userFlags.dates)}
                   disabled={saving || !available.dates}
                   className={`
                     relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full

--- a/apps/frontend/src/components/SettingsModal.tsx
+++ b/apps/frontend/src/components/SettingsModal.tsx
@@ -144,12 +144,12 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 backdrop-blur-sm animate-fade-in"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm animate-fade-in p-4"
       onClick={handleBackdropClick}
     >
       <div
         ref={modalRef}
-        className="w-full max-w-md rounded-t-2xl bg-white p-6 shadow-xl animate-slide-in-up"
+        className="w-full max-w-md max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-6 shadow-xl animate-slide-in-up"
       >
         {/* Header */}
         <div className="flex items-center justify-between mb-6">

--- a/apps/frontend/src/components/SettingsModal.tsx
+++ b/apps/frontend/src/components/SettingsModal.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FocusTrap } from "focus-trap-react";
 import { PushNotificationToggle } from "./PushNotificationToggle";
 import { useFeatureFlags } from "@/hooks/useFeatureFlags";
+import { useModal } from "@/hooks/useModal";
 import { createMcpToken, fetchMcpTokens, revokeMcpToken } from "@/lib/api";
 import type { McpToken } from "@/types";
 
@@ -18,6 +20,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const { dates, delegation, aiAssistant, userFlags, available, setFlag } =
     useFeatureFlags();
+  useModal(isOpen);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [mcpTokens, setMcpTokens] = useState<McpToken[]>([]);
@@ -141,11 +144,14 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     setTimeout(() => setCopied(false), 2000);
   }
 
-  if (!isOpen) return null;
+  const mcpUrl = useMemo(() => {
+    const base =
+      process.env.NEXT_PUBLIC_API_BASE_URL ||
+      (typeof window !== "undefined" ? window.location.origin : "");
+    return new URL("/mcp", base).toString();
+  }, []);
 
-  const mcpBase =
-    process.env.NEXT_PUBLIC_API_BASE_URL || window.location.origin;
-  const mcpUrl = new URL("/mcp", mcpBase).toString();
+  if (!isOpen) return null;
 
   return (
     <div
@@ -154,350 +160,354 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm animate-fade-in p-4"
       onClick={handleBackdropClick}
     >
-      <div
-        ref={modalRef}
-        className="w-full max-w-md max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-6 shadow-xl animate-slide-in-up"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between mb-6">
-          <h2 className="text-lg font-semibold text-gray-900">Settings</h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-full p-2 hover:bg-gray-100 transition-colors"
-            aria-label="Close"
-          >
-            <svg
-              viewBox="0 0 24 24"
-              width="20"
-              height="20"
-              fill="none"
-              stroke="currentColor"
-              className="text-gray-500"
+      <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
+        <div
+          ref={modalRef}
+          className="w-full max-w-md max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-6 shadow-xl animate-slide-in-up"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between mb-6">
+            <h2 className="text-lg font-semibold text-gray-900">Settings</h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-full p-2 hover:bg-gray-100 transition-colors"
+              aria-label="Close"
             >
-              <path
-                d="M18 6 6 18M6 6l12 12"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
-
-        {/* Error message */}
-        {error && (
-          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md text-sm text-red-700">
-            {error}
+              <svg
+                viewBox="0 0 24 24"
+                width="20"
+                height="20"
+                fill="none"
+                stroke="currentColor"
+                className="text-gray-500"
+              >
+                <path
+                  d="M18 6 6 18M6 6l12 12"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
           </div>
-        )}
 
-        {/* Saving indicator */}
-        {saving && (
-          <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-md text-sm text-blue-700">
-            Saving...
-          </div>
-        )}
+          {/* Error message */}
+          {error && (
+            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md text-sm text-red-700">
+              {error}
+            </div>
+          )}
 
-        {/* Settings Content */}
-        <div className="space-y-6">
-          {/* Features Section */}
-          <section>
-            <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider mb-3">
-              Features
-            </h3>
-            <div className="bg-gray-50 rounded-lg p-4 space-y-4">
-              {/* Dates & Scheduling toggle */}
-              <div className="flex items-center gap-3">
-                <button
-                  type="button"
-                  onClick={() => handleToggle("dates", !userFlags.dates)}
-                  disabled={saving || !available.dates}
-                  className={`
+          {/* Saving indicator */}
+          {saving && (
+            <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-md text-sm text-blue-700">
+              Saving...
+            </div>
+          )}
+
+          {/* Settings Content */}
+          <div className="space-y-6">
+            {/* Features Section */}
+            <section>
+              <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider mb-3">
+                Features
+              </h3>
+              <div className="bg-gray-50 rounded-lg p-4 space-y-4">
+                {/* Dates & Scheduling toggle */}
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() => handleToggle("dates", !userFlags.dates)}
+                    disabled={saving || !available.dates}
+                    className={`
                     relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full
                     border-2 border-transparent transition-colors duration-200 ease-in-out
                     focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
                     ${userFlags.dates && available.dates ? "bg-blue-600" : "bg-gray-200"}
                     ${saving || !available.dates ? "opacity-50 cursor-not-allowed" : ""}
                   `}
-                  role="switch"
-                  aria-checked={dates}
-                  aria-label="Dates & Scheduling"
-                >
-                  <span
-                    className={`
+                    role="switch"
+                    aria-checked={dates}
+                    aria-label="Dates & Scheduling"
+                  >
+                    <span
+                      className={`
                       pointer-events-none inline-block h-5 w-5 transform rounded-full
                       bg-white shadow ring-0 transition duration-200 ease-in-out
                       ${userFlags.dates && available.dates ? "translate-x-5" : "translate-x-0"}
                     `}
-                  />
-                </button>
-                <div className="flex flex-col">
-                  <span className="text-sm font-medium text-gray-900">
-                    Dates &amp; Scheduling
-                  </span>
-                  <span className="text-xs text-gray-500">
-                    {available.dates
-                      ? "Due dates, scheduled dates, and repeating tasks"
-                      : "Coming soon"}
-                  </span>
+                    />
+                  </button>
+                  <div className="flex flex-col">
+                    <span className="text-sm font-medium text-gray-900">
+                      Dates &amp; Scheduling
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      {available.dates
+                        ? "Due dates, scheduled dates, and repeating tasks"
+                        : "Coming soon"}
+                    </span>
+                  </div>
                 </div>
-              </div>
 
-              {/* Task Delegation toggle */}
-              <div className="flex items-center gap-3">
-                <button
-                  type="button"
-                  onClick={() =>
-                    handleToggle("delegation", !userFlags.delegation)
-                  }
-                  disabled={saving || !available.delegation}
-                  className={`
+                {/* Task Delegation toggle */}
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      handleToggle("delegation", !userFlags.delegation)
+                    }
+                    disabled={saving || !available.delegation}
+                    className={`
                     relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full
                     border-2 border-transparent transition-colors duration-200 ease-in-out
                     focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
                     ${userFlags.delegation && available.delegation ? "bg-blue-600" : "bg-gray-200"}
                     ${saving || !available.delegation ? "opacity-50 cursor-not-allowed" : ""}
                   `}
-                  role="switch"
-                  aria-checked={delegation}
-                  aria-label="Task Delegation"
-                >
-                  <span
-                    className={`
+                    role="switch"
+                    aria-checked={delegation}
+                    aria-label="Task Delegation"
+                  >
+                    <span
+                      className={`
                       pointer-events-none inline-block h-5 w-5 transform rounded-full
                       bg-white shadow ring-0 transition duration-200 ease-in-out
                       ${userFlags.delegation && available.delegation ? "translate-x-5" : "translate-x-0"}
                     `}
-                  />
-                </button>
-                <div className="flex flex-col">
-                  <span className="text-sm font-medium text-gray-900">
-                    Task Delegation
-                  </span>
-                  <span className="text-xs text-gray-500">
-                    {available.delegation
-                      ? "Assign tasks to other users"
-                      : "Coming soon"}
-                  </span>
+                    />
+                  </button>
+                  <div className="flex flex-col">
+                    <span className="text-sm font-medium text-gray-900">
+                      Task Delegation
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      {available.delegation
+                        ? "Assign tasks to other users"
+                        : "Coming soon"}
+                    </span>
+                  </div>
                 </div>
-              </div>
 
-              {/* AI Assistant toggle */}
-              <div className="flex items-center gap-3">
-                <button
-                  type="button"
-                  onClick={() =>
-                    handleToggle("ai_assistant", !userFlags.ai_assistant)
-                  }
-                  disabled={saving || !available.ai_assistant}
-                  className={`
+                {/* AI Assistant toggle */}
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      handleToggle("ai_assistant", !userFlags.ai_assistant)
+                    }
+                    disabled={saving || !available.ai_assistant}
+                    className={`
                     relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full
                     border-2 border-transparent transition-colors duration-200 ease-in-out
                     focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
                     ${userFlags.ai_assistant && available.ai_assistant ? "bg-blue-600" : "bg-gray-200"}
                     ${saving || !available.ai_assistant ? "opacity-50 cursor-not-allowed" : ""}
                   `}
-                  role="switch"
-                  aria-checked={aiAssistant}
-                  aria-label="AI Assistant"
-                >
-                  <span
-                    className={`
+                    role="switch"
+                    aria-checked={aiAssistant}
+                    aria-label="AI Assistant"
+                  >
+                    <span
+                      className={`
                       pointer-events-none inline-block h-5 w-5 transform rounded-full
                       bg-white shadow ring-0 transition duration-200 ease-in-out
                       ${userFlags.ai_assistant && available.ai_assistant ? "translate-x-5" : "translate-x-0"}
                     `}
-                  />
-                </button>
-                <div className="flex flex-col">
-                  <span className="text-sm font-medium text-gray-900">
-                    AI Assistant (MCP)
-                  </span>
-                  <span className="text-xs text-gray-500">
-                    {available.ai_assistant
-                      ? "Enable MCP token management for agent integrations"
-                      : "Coming soon"}
-                  </span>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          {aiAssistant && (
-            <section>
-              <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider mb-3">
-                AI Assistant Tokens
-              </h3>
-              <div className="bg-gray-50 rounded-lg p-4 space-y-4">
-                {newToken && (
-                  <div className="p-3 bg-green-50 border border-green-200 rounded-md">
-                    <p className="text-xs text-green-800 mb-2">
-                      New token created. Copy it now, you won&apos;t be able to
-                      view it again.
-                    </p>
-                    <div className="flex gap-2 items-center">
-                      <code className="flex-1 text-xs rounded bg-green-100 p-2 break-all">
-                        {newToken}
-                      </code>
-                      <button
-                        type="button"
-                        onClick={copyNewToken}
-                        className="px-3 py-1 text-xs rounded bg-white border border-green-300 hover:bg-green-100"
-                      >
-                        {copied ? "Copied!" : "Copy"}
-                      </button>
-                    </div>
-                  </div>
-                )}
-
-                <form
-                  onSubmit={handleCreateToken}
-                  className="flex items-center gap-2"
-                >
-                  <input
-                    type="text"
-                    value={tokenName}
-                    onChange={(e) => setTokenName(e.target.value)}
-                    placeholder="Token name (e.g. Claude Desktop)"
-                    className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm"
-                  />
-                  <button
-                    type="submit"
-                    disabled={creatingToken || tokenName.trim().length === 0}
-                    className="rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
-                  >
-                    {creatingToken ? "Creating..." : "Create"}
+                    />
                   </button>
-                </form>
-
-                {loadingTokens ? (
-                  <p className="text-xs text-gray-500">Loading tokens...</p>
-                ) : tokenLoadError ? (
-                  <div className="flex items-center gap-2">
-                    <p className="text-xs text-red-600">
-                      Failed to load tokens.
-                    </p>
-                    <button
-                      type="button"
-                      onClick={() => void loadMcpTokens()}
-                      className="text-xs text-blue-600 underline hover:no-underline"
-                    >
-                      Retry
-                    </button>
+                  <div className="flex flex-col">
+                    <span className="text-sm font-medium text-gray-900">
+                      AI Assistant (MCP)
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      {available.ai_assistant
+                        ? "Enable MCP token management for agent integrations"
+                        : "Coming soon"}
+                    </span>
                   </div>
-                ) : mcpTokens.length === 0 ? (
-                  <p className="text-xs text-gray-500">No MCP tokens yet.</p>
-                ) : (
-                  <div className="divide-y rounded-md border border-gray-200 bg-white">
-                    {mcpTokens.map((token) => (
-                      <div
-                        key={token.id}
-                        className="flex items-start justify-between gap-2 p-3"
-                      >
-                        <div className="min-w-0">
-                          <p className="text-sm font-medium text-gray-900">
-                            {token.name}
-                            {token.is_legacy_wildcard && (
-                              <span className="ml-2 rounded bg-amber-100 px-2 py-0.5 text-xs font-normal text-amber-800">
-                                Legacy wildcard
-                              </span>
-                            )}
-                          </p>
-                          <p className="text-xs text-gray-500">
-                            Created{" "}
-                            {token.created_at
-                              ? new Date(token.created_at).toLocaleDateString()
-                              : "—"}
-                            {token.last_used_at
-                              ? ` · Last used ${new Date(token.last_used_at).toLocaleDateString()}`
-                              : ""}
-                          </p>
-                          {token.is_legacy_wildcard && (
-                            <p className="mt-1 text-xs text-amber-700">
-                              Replace this broad token with a dedicated MCP
-                              token.
-                            </p>
-                          )}
-                        </div>
-
-                        {confirmRevokeId === token.id ? (
-                          <div className="flex shrink-0 items-center gap-1">
-                            <span className="text-xs text-gray-600">
-                              Revoke?
-                            </span>
-                            <button
-                              type="button"
-                              onClick={() => void handleRevokeToken(token.id)}
-                              className="rounded-md bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-700"
-                            >
-                              Yes
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => setConfirmRevokeId(null)}
-                              className="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
-                            >
-                              Cancel
-                            </button>
-                          </div>
-                        ) : (
-                          <button
-                            type="button"
-                            onClick={() => setConfirmRevokeId(token.id)}
-                            className="shrink-0 rounded-md border border-red-200 px-2 py-1 text-xs text-red-700 hover:bg-red-50"
-                          >
-                            Revoke
-                          </button>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                )}
-
-                <div className="p-3 rounded-md border border-gray-200 bg-white">
-                  <p className="text-xs text-gray-700 mb-2">
-                    MCP config (header auth):
-                  </p>
-                  <pre className="text-[11px] overflow-x-auto rounded bg-gray-100 p-2 text-gray-800">
-                    {JSON.stringify(
-                      {
-                        mcpServers: {
-                          ballistic: {
-                            url: mcpUrl,
-                            headers: {
-                              Authorization: "Bearer YOUR_MCP_TOKEN",
-                            },
-                          },
-                        },
-                      },
-                      null,
-                      2,
-                    )}
-                  </pre>
                 </div>
               </div>
             </section>
-          )}
 
-          {/* Notifications Section */}
-          <section>
-            <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider mb-3">
-              Notifications
-            </h3>
-            <div className="bg-gray-50 rounded-lg p-4">
-              <PushNotificationToggle />
-            </div>
-          </section>
+            {aiAssistant && (
+              <section>
+                <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider mb-3">
+                  AI Assistant Tokens
+                </h3>
+                <div className="bg-gray-50 rounded-lg p-4 space-y-4">
+                  {newToken && (
+                    <div className="p-3 bg-green-50 border border-green-200 rounded-md">
+                      <p className="text-xs text-green-800 mb-2">
+                        New token created. Copy it now, you won&apos;t be able
+                        to view it again.
+                      </p>
+                      <div className="flex gap-2 items-center">
+                        <code className="flex-1 text-xs rounded bg-green-100 p-2 break-all">
+                          {newToken}
+                        </code>
+                        <button
+                          type="button"
+                          onClick={copyNewToken}
+                          className="px-3 py-1 text-xs rounded bg-white border border-green-300 hover:bg-green-100"
+                        >
+                          {copied ? "Copied!" : "Copy"}
+                        </button>
+                      </div>
+                    </div>
+                  )}
 
-          {/* Version Info */}
-          <section className="pt-4 border-t border-gray-100">
-            <p className="text-xs text-gray-400 text-center">
-              Ballistic v0.15.0
-            </p>
-          </section>
+                  <form
+                    onSubmit={handleCreateToken}
+                    className="flex items-center gap-2"
+                  >
+                    <input
+                      type="text"
+                      value={tokenName}
+                      onChange={(e) => setTokenName(e.target.value)}
+                      placeholder="Token name (e.g. Claude Desktop)"
+                      className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm"
+                    />
+                    <button
+                      type="submit"
+                      disabled={creatingToken || tokenName.trim().length === 0}
+                      className="rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      {creatingToken ? "Creating..." : "Create"}
+                    </button>
+                  </form>
+
+                  {loadingTokens ? (
+                    <p className="text-xs text-gray-500">Loading tokens...</p>
+                  ) : tokenLoadError ? (
+                    <div className="flex items-center gap-2">
+                      <p className="text-xs text-red-600">
+                        Failed to load tokens.
+                      </p>
+                      <button
+                        type="button"
+                        onClick={() => void loadMcpTokens()}
+                        className="text-xs text-blue-600 underline hover:no-underline"
+                      >
+                        Retry
+                      </button>
+                    </div>
+                  ) : mcpTokens.length === 0 ? (
+                    <p className="text-xs text-gray-500">No MCP tokens yet.</p>
+                  ) : (
+                    <div className="divide-y rounded-md border border-gray-200 bg-white">
+                      {mcpTokens.map((token) => (
+                        <div
+                          key={token.id}
+                          className="flex items-start justify-between gap-2 p-3"
+                        >
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium text-gray-900">
+                              {token.name}
+                              {token.is_legacy_wildcard && (
+                                <span className="ml-2 rounded bg-amber-100 px-2 py-0.5 text-xs font-normal text-amber-800">
+                                  Legacy wildcard
+                                </span>
+                              )}
+                            </p>
+                            <p className="text-xs text-gray-500">
+                              Created{" "}
+                              {token.created_at
+                                ? new Date(
+                                    token.created_at,
+                                  ).toLocaleDateString()
+                                : "—"}
+                              {token.last_used_at
+                                ? ` · Last used ${new Date(token.last_used_at).toLocaleDateString()}`
+                                : ""}
+                            </p>
+                            {token.is_legacy_wildcard && (
+                              <p className="mt-1 text-xs text-amber-700">
+                                Replace this broad token with a dedicated MCP
+                                token.
+                              </p>
+                            )}
+                          </div>
+
+                          {confirmRevokeId === token.id ? (
+                            <div className="flex shrink-0 items-center gap-1">
+                              <span className="text-xs text-gray-600">
+                                Revoke?
+                              </span>
+                              <button
+                                type="button"
+                                onClick={() => void handleRevokeToken(token.id)}
+                                className="rounded-md bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-700"
+                              >
+                                Yes
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setConfirmRevokeId(null)}
+                                className="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={() => setConfirmRevokeId(token.id)}
+                              className="shrink-0 rounded-md border border-red-200 px-2 py-1 text-xs text-red-700 hover:bg-red-50"
+                            >
+                              Revoke
+                            </button>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  <div className="p-3 rounded-md border border-gray-200 bg-white">
+                    <p className="text-xs text-gray-700 mb-2">
+                      MCP config (header auth):
+                    </p>
+                    <pre className="text-[11px] overflow-x-auto rounded bg-gray-100 p-2 text-gray-800">
+                      {JSON.stringify(
+                        {
+                          mcpServers: {
+                            ballistic: {
+                              url: mcpUrl,
+                              headers: {
+                                Authorization: "Bearer YOUR_MCP_TOKEN",
+                              },
+                            },
+                          },
+                        },
+                        null,
+                        2,
+                      )}
+                    </pre>
+                  </div>
+                </div>
+              </section>
+            )}
+
+            {/* Notifications Section */}
+            <section>
+              <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider mb-3">
+                Notifications
+              </h3>
+              <div className="bg-gray-50 rounded-lg p-4">
+                <PushNotificationToggle />
+              </div>
+            </section>
+
+            {/* Version Info */}
+            <section className="pt-4 border-t border-gray-100">
+              <p className="text-xs text-gray-400 text-center">
+                Ballistic v0.16.2
+              </p>
+            </section>
+          </div>
         </div>
-      </div>
+      </FocusTrap>
     </div>
   );
 }

--- a/apps/frontend/src/components/SettingsModal.tsx
+++ b/apps/frontend/src/components/SettingsModal.tsx
@@ -94,7 +94,11 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
       setSaving(false);
     } catch (err) {
       console.error("Failed to save feature flag:", err);
-      setError("Failed to save settings. Please try again.");
+      const message =
+        err instanceof Error && err.message
+          ? err.message
+          : "Failed to save settings. Please try again.";
+      setError(message);
       setSaving(false);
     }
   }
@@ -145,6 +149,8 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm animate-fade-in p-4"
       onClick={handleBackdropClick}
     >

--- a/apps/frontend/src/contexts/AuthContext.tsx
+++ b/apps/frontend/src/contexts/AuthContext.tsx
@@ -17,7 +17,11 @@ import {
   logout as authLogout,
   AuthError,
 } from "@/lib/auth";
-import { fetchUser, updateUser as apiUpdateUser, type UserUpdatePayload } from "@/lib/api";
+import {
+  fetchUser,
+  updateUser as apiUpdateUser,
+  type UserUpdatePayload,
+} from "@/lib/api";
 
 interface AuthContextType {
   user: User | null;
@@ -98,12 +102,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const updateUser = useCallback(async (data: UserUpdatePayload) => {
-      const updatedUser = await apiUpdateUser(data);
-      setUser(updatedUser);
-      setStoredUser(updatedUser);
-    },
-    [],
-  );
+    const updatedUser = await apiUpdateUser(data);
+    setUser(updatedUser);
+    setStoredUser(updatedUser);
+  }, []);
 
   const value: AuthContextType = {
     user,

--- a/apps/frontend/src/hooks/useModal.ts
+++ b/apps/frontend/src/hooks/useModal.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+/**
+ * Locks body scroll while a modal is open, restoring the previous value on cleanup.
+ * Apply this in every modal component to prevent background scrolling.
+ */
+export function useModal(isOpen: boolean): void {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [isOpen]);
+}

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -11,6 +11,11 @@ export interface User {
     delegation: boolean;
     ai_assistant: boolean;
   } | null;
+  available_feature_flags?: {
+    dates: boolean;
+    delegation: boolean;
+    ai_assistant: boolean;
+  } | null;
   email_verified_at: string | null;
   created_at: string;
   updated_at: string;

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -6,11 +6,11 @@ export interface User {
   email: string;
   phone: string | null;
   notes: string | null;
-  feature_flags?: {
+  feature_flags: {
     dates: boolean;
     delegation: boolean;
     ai_assistant: boolean;
-  } | null;
+  };
   available_feature_flags?: {
     dates: boolean;
     delegation: boolean;


### PR DESCRIPTION
## Summary

- **Admin feature flag control**: Admins can now globally enable/disable features (`dates`, `delegation`, `ai_assistant`) via `GET/PUT /api/admin/settings/features`. When disabled, users see the toggle greyed out with "Coming soon" and cannot enable it. Re-enabling restores each user's stored preference automatically.
- **Settings modal scrollability** (from prior commit): Converted from a bottom sheet to a centred popup with `max-h-[90vh]` and `overflow-y-auto`.
- **Backend**: New `app_settings` table, `AppSetting` model with 60s cached lookups, `Admin\SettingsController`, global flag enforcement in `UserController` (422 on enable attempt) and `EnsureAiAssistantEnabled` middleware, `available_feature_flags` in `UserResource`.
- **Frontend**: `useFeatureFlags` hook now exposes `userFlags`, `available`, and effective booleans; `SettingsModal` toggles respect global availability; `User` type updated with `available_feature_flags`.

## Test plan

- [ ] Backend: 12 new tests in `GlobalFeatureFlagsTest` — admin CRUD, non-admin rejection, partial updates, user enable/disable enforcement, middleware behaviour, safe defaults
- [ ] Backend: Full suite passes (512 tests, 0 failures)
- [ ] Frontend: 5 new `useFeatureFlags` tests + updated MCP test mock (49 tests, 0 failures)
- [ ] Frontend: TypeScript typecheck and ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)