### PR TITLE
Activity log, notification centre, and profile management (#15)

### DIFF
--- a/apps/backend/app/Http/Controllers/ActivityLogController.php
+++ b/apps/backend/app/Http/Controllers/ActivityLogController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\ActivityLogItemResource;
+use App\Models\Item;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+final class ActivityLogController extends Controller
+{
+    /**
+     * Get cursor-paginated item history for the authenticated user.
+     *
+     * Items are ordered by updated_at descending (most recent first).
+     * Supports cursor pagination for infinite scroll.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $perPage = min((int) $request->input('per_page', 20), 50);
+
+        $items = Item::where('user_id', Auth::id())
+            ->with('project')
+            ->orderBy('updated_at', 'desc')
+            ->cursorPaginate($perPage);
+
+        return ActivityLogItemResource::collection($items)
+            ->response();
+    }
+}

--- a/apps/backend/app/Http/Controllers/Api/UserController.php
+++ b/apps/backend/app/Http/Controllers/Api/UserController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\UpdateProfileRequest;
 use App\Http\Resources\UserResource;
 use App\Models\AppSetting;
 use App\Models\User;
@@ -50,6 +51,8 @@ final class UserController extends Controller
             ],
             'phone' => ['nullable', 'string', 'max:20'],
             'notes' => ['nullable', 'string', 'max:10000'],
+            'bio' => ['nullable', 'string', 'max:500'],
+            'avatar_url' => ['nullable', 'string', 'url', 'max:500'],
             'feature_flags' => ['nullable', 'array'],
             'feature_flags.dates' => ['sometimes', 'boolean'],
             'feature_flags.delegation' => ['sometimes', 'boolean'],
@@ -88,6 +91,30 @@ final class UserController extends Controller
             $user->update($validated);
 
             if (isset($validated['email']) && $validated['email'] !== $user->getOriginal('email')) {
+                $user->email_verified_at = null;
+                $user->save();
+            }
+        });
+
+        return new UserResource($user);
+    }
+
+    /**
+     * Update the authenticated user's profile fields only.
+     *
+     * This is a focused endpoint for profile editing (name, email, phone, bio, avatar_url).
+     */
+    public function updateProfile(UpdateProfileRequest $request): UserResource
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $validated = $request->validated();
+        $originalEmail = $user->email;
+
+        DB::transaction(function () use ($user, $validated, $originalEmail): void {
+            $user->update($validated);
+
+            if (isset($validated['email']) && $validated['email'] !== $originalEmail) {
                 $user->email_verified_at = null;
                 $user->save();
             }

--- a/apps/backend/app/Http/Controllers/NotificationController.php
+++ b/apps/backend/app/Http/Controllers/NotificationController.php
@@ -70,4 +70,21 @@ final class NotificationController extends Controller
             'marked_count' => $count,
         ]);
     }
+
+    /**
+     * Dismiss (delete) a specific notification.
+     */
+    public function dismiss(Notification $notification): JsonResponse
+    {
+        if ((string) $notification->user_id !== (string) Auth::id()) {
+            return response()->json(['message' => 'Forbidden'], Response::HTTP_FORBIDDEN);
+        }
+
+        $notification->delete();
+
+        return response()->json([
+            'message' => 'Notification dismissed.',
+            'unread_count' => $this->notificationService->getUnreadCount(Auth::user()),
+        ]);
+    }
 }

--- a/apps/backend/app/Http/Requests/UpdateProfileRequest.php
+++ b/apps/backend/app/Http/Requests/UpdateProfileRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class UpdateProfileRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorised to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $user = $this->user();
+
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'email' => [
+                'sometimes',
+                'required',
+                'string',
+                'lowercase',
+                'email',
+                'max:255',
+                Rule::unique('users')->ignore($user?->id),
+            ],
+            'phone' => ['nullable', 'string', 'max:20'],
+            'bio' => ['nullable', 'string', 'max:500'],
+            'avatar_url' => ['nullable', 'string', 'url', 'max:500'],
+        ];
+    }
+}

--- a/apps/backend/app/Http/Resources/ActivityLogItemResource.php
+++ b/apps/backend/app/Http/Resources/ActivityLogItemResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class ActivityLogItemResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'status' => $this->status,
+            'project' => new ProjectResource($this->whenLoaded('project')),
+            'completed_at' => $this->completed_at?->toIso8601String(),
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/apps/backend/app/Http/Resources/UserResource.php
+++ b/apps/backend/app/Http/Resources/UserResource.php
@@ -23,6 +23,8 @@ final class UserResource extends JsonResource
             'email' => $this->email,
             'phone' => $this->phone,
             'notes' => $this->notes,
+            'bio' => $this->bio,
+            'avatar_url' => $this->avatar_url,
             'feature_flags' => array_merge(
                 ['dates' => false, 'delegation' => false, 'ai_assistant' => false],
                 $this->feature_flags ?? []

--- a/apps/backend/app/Models/User.php
+++ b/apps/backend/app/Models/User.php
@@ -32,6 +32,8 @@ final class User extends Authenticatable
         'email',
         'phone',
         'notes',
+        'bio',
+        'avatar_url',
         'feature_flags',
         'password',
         'is_admin',

--- a/apps/backend/database/migrations/2026_03_09_130022_add_activity_log_index_to_items_table.php
+++ b/apps/backend/database/migrations/2026_03_09_130022_add_activity_log_index_to_items_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->index(['user_id', 'updated_at'], 'items_activity_log_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->dropIndex('items_activity_log_index');
+        });
+    }
+};

--- a/apps/backend/database/migrations/2026_03_09_130734_add_profile_fields_to_users_table.php
+++ b/apps/backend/database/migrations/2026_03_09_130734_add_profile_fields_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->text('bio')->nullable()->after('notes');
+            $table->string('avatar_url', 500)->nullable()->after('bio');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['bio', 'avatar_url']);
+        });
+    }
+};

--- a/apps/backend/routes/api.php
+++ b/apps/backend/routes/api.php
@@ -35,6 +35,7 @@ Route::middleware(['auth:sanctum', 'token.api', 'throttle:api'])->group(function
     // User profile
     Route::get('/user', [UserController::class, 'show']);
     Route::patch('/user', [UserController::class, 'update']);
+    Route::put('/user/profile', [UserController::class, 'updateProfile']);
 
     // MCP tokens for AI assistant clients (requires ai_assistant feature flag)
     Route::middleware('feature.ai')->group(function () {

--- a/apps/backend/routes/api.php
+++ b/apps/backend/routes/api.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\ActivityLogController;
 use App\Http\Controllers\Admin\SettingsController as AdminSettingsController;
 use App\Http\Controllers\Admin\StatsController as AdminStatsController;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
-use App\Http\Controllers\ActivityLogController;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\FavouriteController;
 use App\Http\Controllers\Api\McpTokenController;

--- a/apps/backend/routes/api.php
+++ b/apps/backend/routes/api.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Http\Controllers\Admin\SettingsController as AdminSettingsController;
 use App\Http\Controllers\Admin\StatsController as AdminStatsController;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
+use App\Http\Controllers\ActivityLogController;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\FavouriteController;
 use App\Http\Controllers\Api\McpTokenController;
@@ -85,6 +86,9 @@ Route::middleware(['auth:sanctum', 'token.api', 'throttle:api'])->group(function
 
     // Tags
     Route::apiResource('tags', TagController::class);
+
+    // Activity log
+    Route::get('/activity-log', [ActivityLogController::class, 'index']);
 
     // Admin routes
     Route::prefix('admin')->middleware(['admin'])->group(function () {

--- a/apps/backend/routes/api.php
+++ b/apps/backend/routes/api.php
@@ -58,6 +58,7 @@ Route::middleware(['auth:sanctum', 'token.api', 'throttle:api'])->group(function
     Route::get('/notifications', [NotificationController::class, 'index']);
     Route::post('/notifications/{notification}/read', [NotificationController::class, 'markAsRead']);
     Route::post('/notifications/read-all', [NotificationController::class, 'markAllAsRead']);
+    Route::delete('/notifications/{notification}', [NotificationController::class, 'dismiss']);
 
     // Push notifications (Web Push subscriptions)
     Route::get('/push/vapid-key', [PushSubscriptionController::class, 'vapidKey']);

--- a/apps/backend/tests/Feature/ActivityLogTest.php
+++ b/apps/backend/tests/Feature/ActivityLogTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Item;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class ActivityLogTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_activity_log_returns_cursor_paginated_items(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['user_id' => $user->id]);
+
+        Item::factory()->count(5)->create([
+            'user_id' => $user->id,
+            'project_id' => $project->id,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/activity-log');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(5, 'data')
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => [
+                        'id',
+                        'title',
+                        'status',
+                        'project',
+                        'completed_at',
+                        'created_at',
+                        'updated_at',
+                    ],
+                ],
+                'meta' => [
+                    'path',
+                    'per_page',
+                    'next_cursor',
+                    'prev_cursor',
+                ],
+            ]);
+    }
+
+    public function test_activity_log_orders_by_updated_at_descending(): void
+    {
+        $user = User::factory()->create();
+
+        $oldest = Item::factory()->create([
+            'user_id' => $user->id,
+            'project_id' => null,
+            'updated_at' => now()->subDays(2),
+        ]);
+
+        $newest = Item::factory()->create([
+            'user_id' => $user->id,
+            'project_id' => null,
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/activity-log');
+
+        $response->assertStatus(200);
+        $data = $response->json('data');
+        $this->assertEquals($newest->id, $data[0]['id']);
+        $this->assertEquals($oldest->id, $data[1]['id']);
+    }
+
+    public function test_activity_log_respects_per_page_parameter(): void
+    {
+        $user = User::factory()->create();
+
+        Item::factory()->count(10)->create([
+            'user_id' => $user->id,
+            'project_id' => null,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/activity-log?per_page=3');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(3, 'data');
+    }
+
+    public function test_activity_log_caps_per_page_at_50(): void
+    {
+        $user = User::factory()->create();
+
+        Item::factory()->count(5)->create([
+            'user_id' => $user->id,
+            'project_id' => null,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/activity-log?per_page=100');
+
+        $response->assertStatus(200);
+        $this->assertEquals(50, $response->json('meta.per_page'));
+    }
+
+    public function test_activity_log_does_not_include_other_users_items(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+
+        Item::factory()->count(3)->create([
+            'user_id' => $user->id,
+            'project_id' => null,
+        ]);
+
+        Item::factory()->count(2)->create([
+            'user_id' => $other->id,
+            'project_id' => null,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/activity-log');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(3, 'data');
+    }
+
+    public function test_activity_log_supports_cursor_pagination(): void
+    {
+        $user = User::factory()->create();
+
+        // Create items with distinct timestamps for stable cursor ordering
+        for ($i = 0; $i < 5; $i++) {
+            Item::factory()->create([
+                'user_id' => $user->id,
+                'project_id' => null,
+                'updated_at' => now()->subMinutes(5 - $i),
+            ]);
+        }
+
+        // Get first page
+        $firstPage = $this->actingAs($user)
+            ->getJson('/api/activity-log?per_page=2');
+
+        $firstPage->assertStatus(200)
+            ->assertJsonCount(2, 'data');
+
+        $nextCursor = $firstPage->json('meta.next_cursor');
+        $this->assertNotNull($nextCursor);
+
+        // Get second page using cursor
+        $secondPage = $this->actingAs($user)
+            ->getJson('/api/activity-log?per_page=2&cursor='.urlencode($nextCursor));
+
+        $secondPage->assertStatus(200)
+            ->assertJsonCount(2, 'data');
+
+        // Ensure no overlap
+        $firstIds = array_column($firstPage->json('data'), 'id');
+        $secondIds = array_column($secondPage->json('data'), 'id');
+        $this->assertEmpty(array_intersect($firstIds, $secondIds));
+    }
+
+    public function test_activity_log_requires_authentication(): void
+    {
+        $response = $this->getJson('/api/activity-log');
+
+        $response->assertStatus(401);
+    }
+}

--- a/apps/backend/tests/Feature/NotificationCentreTest.php
+++ b/apps/backend/tests/Feature/NotificationCentreTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Notification;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class NotificationCentreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_dismiss_own_notification(): void
+    {
+        $user = User::factory()->create();
+
+        $notification = Notification::create([
+            'user_id' => $user->id,
+            'type' => 'task_assigned',
+            'title' => 'Dismissible',
+            'message' => 'This can be dismissed',
+        ]);
+
+        $response = $this->actingAs($user)
+            ->deleteJson("/api/notifications/{$notification->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'message' => 'Notification dismissed.',
+            ]);
+
+        $this->assertDatabaseMissing('notifications', [
+            'id' => $notification->id,
+        ]);
+    }
+
+    public function test_user_cannot_dismiss_other_users_notification(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        $notification = Notification::create([
+            'user_id' => $user1->id,
+            'type' => 'task_assigned',
+            'title' => 'Not yours',
+            'message' => 'This belongs to user 1',
+        ]);
+
+        $response = $this->actingAs($user2)
+            ->deleteJson("/api/notifications/{$notification->id}");
+
+        $response->assertStatus(403);
+
+        $this->assertDatabaseHas('notifications', [
+            'id' => $notification->id,
+        ]);
+    }
+
+    public function test_dismiss_returns_updated_unread_count(): void
+    {
+        $user = User::factory()->create();
+
+        Notification::create([
+            'user_id' => $user->id,
+            'type' => 'task_assigned',
+            'title' => 'Notification 1',
+            'message' => 'Unread 1',
+        ]);
+
+        $toDismiss = Notification::create([
+            'user_id' => $user->id,
+            'type' => 'task_assigned',
+            'title' => 'Notification 2',
+            'message' => 'Unread 2',
+        ]);
+
+        $response = $this->actingAs($user)
+            ->deleteJson("/api/notifications/{$toDismiss->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'unread_count' => 1,
+            ]);
+    }
+
+    public function test_mark_as_read_returns_correct_unread_count(): void
+    {
+        $user = User::factory()->create();
+
+        $notification = Notification::create([
+            'user_id' => $user->id,
+            'type' => 'task_assigned',
+            'title' => 'Read me',
+            'message' => 'Mark as read test',
+        ]);
+
+        Notification::create([
+            'user_id' => $user->id,
+            'type' => 'task_assigned',
+            'title' => 'Other',
+            'message' => 'Still unread',
+        ]);
+
+        $response = $this->actingAs($user)
+            ->postJson("/api/notifications/{$notification->id}/read");
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'unread_count' => 1,
+            ]);
+    }
+
+    public function test_notifications_include_human_readable_timestamp(): void
+    {
+        $user = User::factory()->create();
+
+        Notification::create([
+            'user_id' => $user->id,
+            'type' => 'task_assigned',
+            'title' => 'Recent',
+            'message' => 'Just now notification',
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/notifications');
+
+        $response->assertStatus(200);
+        $data = $response->json('data');
+        $this->assertArrayHasKey('created_at_human', $data[0]);
+    }
+
+    public function test_dismiss_requires_authentication(): void
+    {
+        $user = User::factory()->create();
+
+        $notification = Notification::create([
+            'user_id' => $user->id,
+            'type' => 'task_assigned',
+            'title' => 'Auth test',
+            'message' => 'Requires auth',
+        ]);
+
+        $response = $this->deleteJson("/api/notifications/{$notification->id}");
+
+        $response->assertStatus(401);
+    }
+}

--- a/apps/backend/tests/Feature/UserProfileTest.php
+++ b/apps/backend/tests/Feature/UserProfileTest.php
@@ -145,7 +145,7 @@ final class UserProfileTest extends TestCase
             'email_verified_at' => now(),
         ]);
 
-        $newEmail = 'newemail' . time() . '@example.com';
+        $newEmail = 'newemail'.time().'@example.com';
 
         $response = $this->actingAs($user)
             ->putJson('/api/user/profile', [

--- a/apps/backend/tests/Feature/UserProfileTest.php
+++ b/apps/backend/tests/Feature/UserProfileTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class UserProfileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_view_profile(): void
+    {
+        $user = User::factory()->create([
+            'bio' => 'Test bio',
+            'avatar_url' => 'https://example.com/avatar.jpg',
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/user');
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'name' => $user->name,
+                'email' => $user->email,
+                'bio' => 'Test bio',
+                'avatar_url' => 'https://example.com/avatar.jpg',
+            ]);
+    }
+
+    public function test_user_can_update_bio(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/user/profile', [
+                'name' => $user->name,
+                'email' => $user->email,
+                'bio' => 'My new bio',
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'bio' => 'My new bio',
+            ]);
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'bio' => 'My new bio',
+        ]);
+    }
+
+    public function test_user_can_update_avatar_url(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/user/profile', [
+                'name' => $user->name,
+                'email' => $user->email,
+                'avatar_url' => 'https://example.com/new-avatar.png',
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'avatar_url' => 'https://example.com/new-avatar.png',
+            ]);
+    }
+
+    public function test_bio_cannot_exceed_500_characters(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/user/profile', [
+                'name' => $user->name,
+                'email' => $user->email,
+                'bio' => str_repeat('a', 501),
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['bio']);
+    }
+
+    public function test_avatar_url_must_be_valid_url(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/user/profile', [
+                'name' => $user->name,
+                'email' => $user->email,
+                'avatar_url' => 'not-a-url',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['avatar_url']);
+    }
+
+    public function test_user_can_clear_bio_and_avatar(): void
+    {
+        $user = User::factory()->create([
+            'bio' => 'Old bio',
+            'avatar_url' => 'https://example.com/old.jpg',
+        ]);
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/user/profile', [
+                'name' => $user->name,
+                'email' => $user->email,
+                'bio' => null,
+                'avatar_url' => null,
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'bio' => null,
+                'avatar_url' => null,
+            ]);
+    }
+
+    public function test_profile_update_via_patch_includes_new_fields(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->patchJson('/api/user', [
+                'bio' => 'Patch bio',
+                'avatar_url' => 'https://example.com/patch.jpg',
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'bio' => 'Patch bio',
+                'avatar_url' => 'https://example.com/patch.jpg',
+            ]);
+    }
+
+    public function test_email_change_resets_verification(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        $newEmail = 'newemail' . time() . '@example.com';
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/user/profile', [
+                'name' => $user->name,
+                'email' => $newEmail,
+            ]);
+
+        $response->assertStatus(200);
+        $this->assertNull($user->fresh()->email_verified_at);
+    }
+
+    public function test_profile_update_requires_authentication(): void
+    {
+        $response = $this->putJson('/api/user/profile', [
+            'name' => 'Test',
+            'email' => 'test@example.com',
+        ]);
+
+        $response->assertStatus(401);
+    }
+}

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -1,3 +1,41 @@
+## 0.17.0 - 2026-03-10
+
+### Added
+
+#### Activity Log (#15)
+
+- **`ActivityLogModal`**: New modal displaying cursor-paginated item history, ordered by most recently updated. Shows item title, status badge, project with colour dot, and formatted timestamp. Supports infinite scroll via "Load more" button
+- **`useCursorPagination` hook**: Reusable generic hook for cursor-paginated API endpoints with `loadInitial`, `loadMore`, and `reset` capabilities
+- **`fetchActivityLog` API function**: Fetches `/api/activity-log` with cursor and per_page support
+- **`ActivityLogController`**: Backend endpoint returning cursor-paginated items scoped to the authenticated user, with project eager-loaded. Per-page capped at 50
+- **`ActivityLogItemResource`**: API resource transforming items for the activity log response
+- **Activity log database index**: Composite index on `(user_id, updated_at)` for efficient activity log queries
+
+#### Notification Centre (#15)
+
+- **`NotificationCentre` component**: Dropdown notification panel in the bottom bar with bell icon, unread badge (capped at 99+), polling every 30 seconds when delegation is enabled. Supports mark as read, mark all as read, and dismiss (delete) actions
+- **`NotificationController`**: Backend endpoints for listing notifications (with optional unread-only filter), marking individual/all as read, and dismissing. Includes ownership checks via string-cast UUID comparison
+- **Notification API functions**: `fetchNotifications`, `markNotificationAsRead`, `markAllNotificationsAsRead`, `dismissNotification`
+
+#### Profile Management (#15)
+
+- **`ProfileModal` — bio and avatar fields**: Added textarea for bio (max 500 chars with counter) and URL input for avatar. Avatar displays as a rounded image when set, falling back to initials
+- **`PUT /api/user/profile` endpoint**: Dedicated profile update endpoint using `UpdateProfileRequest` form request with validation for name, email, phone, bio (max 500), and avatar_url (valid URL, max 500)
+- **User model**: Added `bio` and `avatar_url` to fillable fields
+- **Database migration**: Added `bio` (text, nullable) and `avatar_url` (string 500, nullable) columns to users table
+
+### Fixed
+
+- **`ProfileModal` — avatar `<img>` → `next/image`**: Replaced raw `<img>` tag with Next.js `Image` component (unoptimised) to satisfy `@next/next/no-img-element` lint rule
+- **Pint style fixes**: Corrected import ordering in `routes/api.php` and concat spacing in `UserProfileTest.php`
+- **Prettier formatting**: Fixed line-length issues in `NotificationCentre.tsx`
+
+### Tests
+
+- **`ActivityLogTest`**: 7 tests — cursor pagination, ordering, per_page, cap at 50, user scoping, cursor navigation, auth requirement
+- **`NotificationCentreTest`**: 6 tests — dismiss own, cannot dismiss others', unread count after dismiss, mark as read count, human-readable timestamp, auth requirement
+- **`UserProfileTest`**: 9 tests — view profile, update bio, update avatar, bio max length, avatar URL validation, clear fields, patch includes new fields, email change resets verification, auth requirement
+
 ## 0.16.2 - 2026-03-08
 
 ### Changed

--- a/apps/frontend/src/__tests__/profile-modal.test.tsx
+++ b/apps/frontend/src/__tests__/profile-modal.test.tsx
@@ -12,6 +12,8 @@ const mockUser = {
   email: "jane@example.com",
   phone: "0412345678",
   notes: null,
+  bio: null,
+  avatar_url: null,
   feature_flags: { dates: false, delegation: false, ai_assistant: false },
   email_verified_at: "2026-01-01T00:00:00Z",
   created_at: "2026-01-01T00:00:00Z",
@@ -83,6 +85,8 @@ describe("ProfileModal", () => {
     expect(call.name).toBe("Jane Doe");
     expect(call.email).toBe("jane@example.com");
     expect(call.phone).toBe("0412345678");
+    expect(call.bio).toBeNull();
+    expect(call.avatar_url).toBeNull();
 
     expect(refreshUserMock).toHaveBeenCalledTimes(1);
   });

--- a/apps/frontend/src/__tests__/use-feature-flags.test.tsx
+++ b/apps/frontend/src/__tests__/use-feature-flags.test.tsx
@@ -63,6 +63,8 @@ describe("useFeatureFlags", () => {
       email: "test@example.com",
       phone: null,
       notes: null,
+      bio: null,
+      avatar_url: null,
       feature_flags: {
         dates: false,
         delegation: false,
@@ -107,6 +109,8 @@ describe("useFeatureFlags", () => {
       email: "test@example.com",
       phone: null,
       notes: null,
+      bio: null,
+      avatar_url: null,
       feature_flags: { dates: true, delegation: true, ai_assistant: true },
       available_feature_flags: {
         dates: false,
@@ -132,6 +136,8 @@ describe("useFeatureFlags", () => {
       email: "test@example.com",
       phone: null,
       notes: null,
+      bio: null,
+      avatar_url: null,
       feature_flags: { dates: false, delegation: true, ai_assistant: true },
       available_feature_flags: {
         dates: true,
@@ -156,6 +162,8 @@ describe("useFeatureFlags", () => {
       email: "test@example.com",
       phone: null,
       notes: null,
+      bio: null,
+      avatar_url: null,
       feature_flags: { dates: true, delegation: true, ai_assistant: true },
       available_feature_flags: {
         dates: true,
@@ -181,6 +189,8 @@ describe("useFeatureFlags", () => {
       email: "test@example.com",
       phone: null,
       notes: null,
+      bio: null,
+      avatar_url: null,
       feature_flags: { dates: true, delegation: true, ai_assistant: true },
       // no available_feature_flags
       email_verified_at: null,
@@ -204,6 +214,8 @@ describe("useFeatureFlags", () => {
       email: "test@example.com",
       phone: null,
       notes: null,
+      bio: null,
+      avatar_url: null,
       feature_flags: { dates: true, delegation: false, ai_assistant: true },
       available_feature_flags: {
         dates: false,

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -20,6 +20,7 @@ import { NotesModal } from "@/components/NotesModal";
 import { EditItemModal } from "@/components/EditItemModal";
 import { ProfileModal } from "@/components/ProfileModal";
 import { ActivityLogModal } from "@/components/ActivityLogModal";
+import { NotificationCentre } from "@/components/NotificationCentre";
 import { useAuth } from "@/contexts/AuthContext";
 
 function normaliseItemResponse(payload: Item | { data?: Item }): Item {
@@ -836,6 +837,7 @@ export default function Home() {
                 <path d="M3 5h18l-7 8v5l-4 2v-7L3 5z" strokeWidth="1.5" />
               </svg>
             </button>
+            <NotificationCentre delegation={delegation} />
             <button
               type="button"
               aria-label="Profile"

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -19,6 +19,7 @@ import { SettingsModal } from "@/components/SettingsModal";
 import { NotesModal } from "@/components/NotesModal";
 import { EditItemModal } from "@/components/EditItemModal";
 import { ProfileModal } from "@/components/ProfileModal";
+import { ActivityLogModal } from "@/components/ActivityLogModal";
 import { useAuth } from "@/contexts/AuthContext";
 
 function normaliseItemResponse(payload: Item | { data?: Item }): Item {
@@ -100,6 +101,7 @@ export default function Home() {
   const [showSettings, setShowSettings] = useState(false);
   const [showNotes, setShowNotes] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
+  const [showActivityLog, setShowActivityLog] = useState(false);
   const { dates, delegation } = useFeatureFlags();
 
   const showError = useCallback((message: string) => {
@@ -767,6 +769,35 @@ export default function Home() {
                 />
               </svg>
             </button>
+            <button
+              type="button"
+              aria-label="Activity Log"
+              onClick={() => setShowActivityLog(true)}
+              className="tap-target grid h-10 w-10 place-items-center rounded-md hover:bg-slate-100 active:scale-95 transition-all duration-200"
+            >
+              {/* clock/history icon */}
+              <svg
+                viewBox="0 0 24 24"
+                width="20"
+                height="20"
+                fill="none"
+                stroke="currentColor"
+                className="text-[var(--navy)]"
+              >
+                <path
+                  d="M12 8v4l3 3M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"
+                  strokeWidth="1.4"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 3v5h5"
+                  strokeWidth="1.4"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
           </div>
           <button
             type="button"
@@ -845,6 +876,12 @@ export default function Home() {
       <ProfileModal
         isOpen={showProfile}
         onClose={() => setShowProfile(false)}
+      />
+
+      {/* Activity Log Modal */}
+      <ActivityLogModal
+        isOpen={showActivityLog}
+        onClose={() => setShowActivityLog(false)}
       />
 
       {/* Edit/Create Item Modal */}

--- a/apps/frontend/src/components/ActivityLogModal.tsx
+++ b/apps/frontend/src/components/ActivityLogModal.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { FocusTrap } from "focus-trap-react";
+import { useModal } from "@/hooks/useModal";
+import { useCursorPagination } from "@/hooks/useCursorPagination";
+import { fetchActivityLog, type ActivityLogItem } from "@/lib/api";
+
+interface ActivityLogModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  todo: "To Do",
+  doing: "Doing",
+  done: "Done",
+  wontdo: "Won\u2019t Do",
+};
+
+const STATUS_COLOURS: Record<string, string> = {
+  todo: "bg-slate-200 text-slate-700",
+  doing: "bg-blue-100 text-blue-700",
+  done: "bg-green-100 text-green-700",
+  wontdo: "bg-red-100 text-red-700",
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-AU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function ActivityLogModal({ isOpen, onClose }: ActivityLogModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  useModal(isOpen);
+
+  const fetchFn = useCallback(
+    (cursor?: string) => fetchActivityLog(cursor),
+    [],
+  );
+
+  const {
+    items,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    error,
+    loadInitial,
+    loadMore,
+    reset,
+  } = useCursorPagination<ActivityLogItem>(fetchFn);
+
+  useEffect(() => {
+    if (isOpen) {
+      reset();
+      void loadInitial();
+    }
+  }, [isOpen, loadInitial, reset]);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }
+  }, [isOpen, onClose]);
+
+  function handleBackdropClick(e: React.MouseEvent) {
+    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+      onClose();
+    }
+  }
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm animate-fade-in p-4"
+      onClick={handleBackdropClick}
+    >
+      <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
+        <div
+          ref={modalRef}
+          className="w-full max-w-md max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-6 shadow-xl animate-slide-in-up"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-gray-900">
+              Activity Log
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-full p-2 hover:bg-gray-100 transition-colors"
+              aria-label="Close"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                width="20"
+                height="20"
+                fill="none"
+                stroke="currentColor"
+                className="text-gray-500"
+              >
+                <path
+                  d="M18 6 6 18M6 6l12 12"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          {/* Loading */}
+          {isLoading && (
+            <p className="text-sm text-gray-500 text-center py-8">
+              Loading activity...
+            </p>
+          )}
+
+          {/* Empty state */}
+          {!isLoading && items.length === 0 && !error && (
+            <p className="text-sm text-gray-500 text-center py-8">
+              No activity yet.
+            </p>
+          )}
+
+          {/* Items */}
+          {items.length > 0 && (
+            <div className="space-y-2">
+              {items.map((item) => (
+                <div
+                  key={item.id}
+                  className="flex items-start gap-3 p-3 rounded-lg bg-gray-50 border border-gray-100"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-gray-900 truncate">
+                      {item.title}
+                    </p>
+                    <div className="flex items-center gap-2 mt-1">
+                      <span
+                        className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLOURS[item.status] || "bg-gray-100 text-gray-600"}`}
+                      >
+                        {STATUS_LABELS[item.status] || item.status}
+                      </span>
+                      {item.project && (
+                        <span className="flex items-center gap-1 text-xs text-gray-500">
+                          {item.project.color && (
+                            <span
+                              className="inline-block h-2 w-2 rounded-full"
+                              style={{ backgroundColor: item.project.color }}
+                            />
+                          )}
+                          {item.project.name}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-gray-400 mt-1">
+                      {formatDate(item.updated_at)}
+                    </p>
+                  </div>
+                </div>
+              ))}
+
+              {/* Load more */}
+              {hasMore && (
+                <button
+                  type="button"
+                  onClick={() => void loadMore()}
+                  disabled={isLoadingMore}
+                  className="w-full py-2 text-sm text-blue-600 hover:text-blue-800 disabled:opacity-50 transition-colors"
+                >
+                  {isLoadingMore ? "Loading..." : "Load more"}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </FocusTrap>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/NotificationCentre.tsx
+++ b/apps/frontend/src/components/NotificationCentre.tsx
@@ -94,7 +94,10 @@ export function NotificationCentre({ delegation }: NotificationCentreProps) {
     try {
       await markAllNotificationsAsRead();
       setNotifications((prev) =>
-        prev.map((n) => ({ ...n, read_at: n.read_at || new Date().toISOString() })),
+        prev.map((n) => ({
+          ...n,
+          read_at: n.read_at || new Date().toISOString(),
+        })),
       );
       setUnreadCount(0);
     } catch (err) {
@@ -175,9 +178,7 @@ export function NotificationCentre({ delegation }: NotificationCentreProps) {
 
           {/* Loading */}
           {loading && notifications.length === 0 && (
-            <p className="text-sm text-gray-500 text-center py-6">
-              Loading...
-            </p>
+            <p className="text-sm text-gray-500 text-center py-6">Loading...</p>
           )}
 
           {/* Empty */}
@@ -194,9 +195,7 @@ export function NotificationCentre({ delegation }: NotificationCentreProps) {
                 <div
                   key={notification.id}
                   className={`flex items-start gap-3 px-4 py-3 transition-colors ${
-                    !notification.read_at
-                      ? "bg-blue-50/50"
-                      : "hover:bg-gray-50"
+                    !notification.read_at ? "bg-blue-50/50" : "hover:bg-gray-50"
                   }`}
                 >
                   <div className="min-w-0 flex-1">

--- a/apps/frontend/src/components/NotificationCentre.tsx
+++ b/apps/frontend/src/components/NotificationCentre.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Notification, NotificationsResponse } from "@/types";
+import {
+  fetchNotifications,
+  markNotificationAsRead,
+  markAllNotificationsAsRead,
+  dismissNotification,
+} from "@/lib/api";
+
+interface NotificationCentreProps {
+  delegation: boolean;
+}
+
+export function NotificationCentre({ delegation }: NotificationCentreProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const response: NotificationsResponse = await fetchNotifications();
+      setNotifications(response.data);
+      setUnreadCount(response.unread_count);
+    } catch (err) {
+      console.error("Failed to fetch notifications:", err);
+    }
+  }, []);
+
+  // Poll for new notifications every 30s when delegation is on
+  useEffect(() => {
+    if (!delegation) {
+      setNotifications([]);
+      setUnreadCount(0);
+      return;
+    }
+
+    void load();
+    pollRef.current = setInterval(() => void load(), 30_000);
+
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [delegation, load]);
+
+  // Close on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClick);
+      return () => document.removeEventListener("mousedown", handleClick);
+    }
+  }, [isOpen]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setIsOpen(false);
+    }
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }
+  }, [isOpen]);
+
+  async function handleMarkAsRead(id: string) {
+    try {
+      const result = await markNotificationAsRead(id);
+      setNotifications((prev) =>
+        prev.map((n) =>
+          n.id === id ? { ...n, read_at: new Date().toISOString() } : n,
+        ),
+      );
+      setUnreadCount(result.unread_count);
+    } catch (err) {
+      console.error("Failed to mark notification as read:", err);
+    }
+  }
+
+  async function handleMarkAllAsRead() {
+    try {
+      await markAllNotificationsAsRead();
+      setNotifications((prev) =>
+        prev.map((n) => ({ ...n, read_at: n.read_at || new Date().toISOString() })),
+      );
+      setUnreadCount(0);
+    } catch (err) {
+      console.error("Failed to mark all as read:", err);
+    }
+  }
+
+  async function handleDismiss(id: string) {
+    try {
+      const result = await dismissNotification(id);
+      setNotifications((prev) => prev.filter((n) => n.id !== id));
+      setUnreadCount(result.unread_count);
+    } catch (err) {
+      console.error("Failed to dismiss notification:", err);
+    }
+  }
+
+  async function handleToggle() {
+    if (!isOpen && !loading) {
+      setLoading(true);
+      await load();
+      setLoading(false);
+    }
+    setIsOpen((prev) => !prev);
+  }
+
+  if (!delegation) return null;
+
+  return (
+    <div ref={dropdownRef} className="relative">
+      {/* Bell button */}
+      <button
+        type="button"
+        aria-label="Notifications"
+        onClick={() => void handleToggle()}
+        className="tap-target grid h-10 w-10 place-items-center rounded-md hover:bg-slate-100 active:scale-95 transition-all duration-200 relative"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          width="20"
+          height="20"
+          fill="none"
+          stroke="currentColor"
+          className="text-[var(--navy)]"
+        >
+          <path
+            d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 0 1-3.46 0"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        {unreadCount > 0 && (
+          <span className="absolute top-1 right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {/* Dropdown */}
+      {isOpen && (
+        <div className="absolute bottom-full right-0 mb-2 w-80 max-h-96 overflow-y-auto rounded-xl bg-white shadow-xl border border-slate-200/50 animate-slide-in-up z-50">
+          {/* Header */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+            <h3 className="text-sm font-semibold text-gray-900">
+              Notifications
+            </h3>
+            {unreadCount > 0 && (
+              <button
+                type="button"
+                onClick={() => void handleMarkAllAsRead()}
+                className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+              >
+                Mark all as read
+              </button>
+            )}
+          </div>
+
+          {/* Loading */}
+          {loading && notifications.length === 0 && (
+            <p className="text-sm text-gray-500 text-center py-6">
+              Loading...
+            </p>
+          )}
+
+          {/* Empty */}
+          {!loading && notifications.length === 0 && (
+            <p className="text-sm text-gray-500 text-center py-6">
+              No notifications yet.
+            </p>
+          )}
+
+          {/* List */}
+          {notifications.length > 0 && (
+            <div className="divide-y divide-gray-50">
+              {notifications.map((notification) => (
+                <div
+                  key={notification.id}
+                  className={`flex items-start gap-3 px-4 py-3 transition-colors ${
+                    !notification.read_at
+                      ? "bg-blue-50/50"
+                      : "hover:bg-gray-50"
+                  }`}
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-gray-900">
+                      {notification.title}
+                    </p>
+                    <p className="text-xs text-gray-600 mt-0.5">
+                      {notification.message}
+                    </p>
+                    <p className="text-xs text-gray-400 mt-1">
+                      {formatTimeAgo(notification.created_at)}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    {!notification.read_at && (
+                      <button
+                        type="button"
+                        onClick={() => void handleMarkAsRead(notification.id)}
+                        className="p-1 rounded hover:bg-blue-100 transition-colors"
+                        title="Mark as read"
+                      >
+                        <svg
+                          viewBox="0 0 24 24"
+                          width="14"
+                          height="14"
+                          fill="none"
+                          stroke="currentColor"
+                          className="text-blue-600"
+                        >
+                          <path
+                            d="M20 6 9 17l-5-5"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => void handleDismiss(notification.id)}
+                      className="p-1 rounded hover:bg-red-100 transition-colors"
+                      title="Dismiss"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        width="14"
+                        height="14"
+                        fill="none"
+                        stroke="currentColor"
+                        className="text-gray-400"
+                      >
+                        <path
+                          d="M18 6 6 18M6 6l12 12"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatTimeAgo(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  const diffMs = now - then;
+  const diffMins = Math.floor(diffMs / 60_000);
+  const diffHours = Math.floor(diffMs / 3_600_000);
+  const diffDays = Math.floor(diffMs / 86_400_000);
+
+  if (diffMins < 1) return "Just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return new Date(iso).toLocaleDateString("en-AU", {
+    day: "numeric",
+    month: "short",
+  });
+}

--- a/apps/frontend/src/components/ProfileModal.tsx
+++ b/apps/frontend/src/components/ProfileModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import Image from "next/image";
 import { FocusTrap } from "focus-trap-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useModal } from "@/hooks/useModal";
@@ -148,9 +149,12 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
           {/* Avatar */}
           <div className="flex justify-center mb-6">
             {user.avatar_url ? (
-              <img
+              <Image
                 src={user.avatar_url}
                 alt={user.name}
+                width={64}
+                height={64}
+                unoptimized
                 className="h-16 w-16 rounded-full object-cover"
               />
             ) : (

--- a/apps/frontend/src/components/ProfileModal.tsx
+++ b/apps/frontend/src/components/ProfileModal.tsx
@@ -18,6 +18,8 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
+  const [bio, setBio] = useState("");
+  const [avatarUrl, setAvatarUrl] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
@@ -28,6 +30,8 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
       setName(user.name);
       setEmail(user.email);
       setPhone(user.phone ?? "");
+      setBio(user.bio ?? "");
+      setAvatarUrl(user.avatar_url ?? "");
       setError(null);
       setSuccess(false);
     }
@@ -70,6 +74,8 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
         name: name.trim(),
         email: email.trim(),
         phone: phone.trim() || null,
+        bio: bio.trim() || null,
+        avatar_url: avatarUrl.trim() || null,
       });
       await refreshUser();
       setSuccess(true);
@@ -141,9 +147,17 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
 
           {/* Avatar */}
           <div className="flex justify-center mb-6">
-            <div className="h-16 w-16 rounded-full bg-[var(--blue)] flex items-center justify-center text-white text-xl font-semibold">
-              {initials}
-            </div>
+            {user.avatar_url ? (
+              <img
+                src={user.avatar_url}
+                alt={user.name}
+                className="h-16 w-16 rounded-full object-cover"
+              />
+            ) : (
+              <div className="h-16 w-16 rounded-full bg-[var(--blue)] flex items-center justify-center text-white text-xl font-semibold">
+                {initials}
+              </div>
+            )}
           </div>
 
           {/* Feedback */}
@@ -209,6 +223,46 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
                 value={phone}
                 onChange={(e) => setPhone(e.target.value)}
                 placeholder="Optional"
+                disabled={saving}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="profile-bio"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Bio
+              </label>
+              <textarea
+                id="profile-bio"
+                value={bio}
+                onChange={(e) => setBio(e.target.value)}
+                placeholder="Tell us about yourself"
+                maxLength={500}
+                rows={3}
+                disabled={saving}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50 resize-none"
+              />
+              <p className="text-xs text-gray-400 mt-1 text-right">
+                {bio.length}/500
+              </p>
+            </div>
+
+            <div>
+              <label
+                htmlFor="profile-avatar"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Avatar URL
+              </label>
+              <input
+                id="profile-avatar"
+                type="url"
+                value={avatarUrl}
+                onChange={(e) => setAvatarUrl(e.target.value)}
+                placeholder="https://example.com/avatar.jpg"
                 disabled={saving}
                 className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50"
               />

--- a/apps/frontend/src/hooks/useCursorPagination.ts
+++ b/apps/frontend/src/hooks/useCursorPagination.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+interface CursorPaginationResult<T> {
+  items: T[];
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  error: string | null;
+  loadInitial: () => Promise<void>;
+  loadMore: () => Promise<void>;
+  reset: () => void;
+}
+
+interface CursorPaginatedResponse<T> {
+  data: T[];
+  meta: {
+    next_cursor: string | null;
+    prev_cursor: string | null;
+    per_page: number;
+    path: string;
+  };
+}
+
+/**
+ * Reusable hook for cursor-paginated API endpoints.
+ */
+export function useCursorPagination<T>(
+  fetchFn: (cursor?: string) => Promise<CursorPaginatedResponse<T>>,
+): CursorPaginationResult<T> {
+  const [items, setItems] = useState<T[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadInitial = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetchFn();
+      setItems(response.data);
+      setNextCursor(response.meta.next_cursor);
+      setHasMore(response.meta.next_cursor !== null);
+    } catch (err) {
+      console.error("Failed to load items:", err);
+      setError("Failed to load activity log.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [fetchFn]);
+
+  const loadMore = useCallback(async () => {
+    if (!nextCursor || isLoadingMore) return;
+
+    setIsLoadingMore(true);
+    setError(null);
+    try {
+      const response = await fetchFn(nextCursor);
+      setItems((prev) => [...prev, ...response.data]);
+      setNextCursor(response.meta.next_cursor);
+      setHasMore(response.meta.next_cursor !== null);
+    } catch (err) {
+      console.error("Failed to load more items:", err);
+      setError("Failed to load more items.");
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [fetchFn, nextCursor, isLoadingMore]);
+
+  const reset = useCallback(() => {
+    setItems([]);
+    setNextCursor(null);
+    setHasMore(true);
+    setError(null);
+  }, []);
+
+  return {
+    items,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    error,
+    loadInitial,
+    loadMore,
+    reset,
+  };
+}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -105,7 +105,7 @@ export async function fetchUser(): Promise<User> {
 }
 
 export type UserUpdatePayload = Partial<
-  Pick<User, "name" | "email" | "phone" | "notes"> & {
+  Pick<User, "name" | "email" | "phone" | "notes" | "bio" | "avatar_url"> & {
     // feature_flags accepts a partial update — the server merges it with stored flags.
     feature_flags: Partial<NonNullable<User["feature_flags"]>> | null;
   }

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -487,6 +487,50 @@ export async function markAllNotificationsAsRead(): Promise<{
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Activity Log
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ActivityLogItem {
+  id: string;
+  title: string;
+  status: string;
+  project: { id: string; name: string; color: string | null } | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CursorPaginatedResponse<T> {
+  data: T[];
+  meta: {
+    next_cursor: string | null;
+    prev_cursor: string | null;
+    per_page: number;
+    path: string;
+  };
+}
+
+/**
+ * Fetch cursor-paginated activity log (item history) for the authenticated user.
+ */
+export async function fetchActivityLog(
+  cursor?: string,
+): Promise<CursorPaginatedResponse<ActivityLogItem>> {
+  const params: Record<string, string | undefined> = {
+    per_page: "20",
+    cursor,
+  };
+
+  const response = await fetch(buildUrl("/api/activity-log", params), {
+    method: "GET",
+    headers: getAuthHeaders(),
+    cache: "no-store",
+  });
+
+  return handleResponse<CursorPaginatedResponse<ActivityLogItem>>(response);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Push Notifications (Web Push)
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -486,6 +486,23 @@ export async function markAllNotificationsAsRead(): Promise<{
   return handleResponse<{ message: string; marked_count: number }>(response);
 }
 
+/**
+ * Dismiss (delete) a specific notification.
+ */
+export async function dismissNotification(
+  notificationId: string,
+): Promise<{ message: string; unread_count: number }> {
+  const response = await fetch(
+    buildUrl(`/api/notifications/${notificationId}`),
+    {
+      method: "DELETE",
+      headers: getAuthHeaders(),
+    },
+  );
+
+  return handleResponse<{ message: string; unread_count: number }>(response);
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Activity Log
 // ─────────────────────────────────────────────────────────────────────────────

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -6,6 +6,8 @@ export interface User {
   email: string;
   phone: string | null;
   notes: string | null;
+  bio: string | null;
+  avatar_url: string | null;
   feature_flags: {
     dates: boolean;
     delegation: boolean;


### PR DESCRIPTION
## Summary

Implements three features for GitHub issue #15:

- **Activity log** — Cursor-paginated item history modal showing all user tasks ordered by most recently updated, with status badges, project indicators, and infinite scroll via a reusable `useCursorPagination` hook. Backend adds `ActivityLogController` with a composite `(user_id, updated_at)` index for efficient queries
- **Notification centre** — Dropdown panel with bell icon and unread badge in the bottom bar. Supports mark as read, mark all as read, and dismiss actions. Polls every 30s when delegation is enabled. Backend `NotificationController` includes ownership checks on all mutation endpoints
- **Profile management** — Bio (max 500 chars) and avatar URL fields added to user profile. Dedicated `PUT /api/user/profile` endpoint with `UpdateProfileRequest` form request validation. Avatar renders via `next/image` with initials fallback

## Changes

### Backend
- `ActivityLogController` — cursor-paginated `/api/activity-log` endpoint scoped to authenticated user, per_page capped at 50
- `ActivityLogItemResource` — API resource for activity log items with project eager-loading
- `NotificationController` — list (with unread filter), mark read, mark all read, dismiss endpoints with UUID ownership checks
- `UpdateProfileRequest` — form request validating name, email, phone, bio (max 500), avatar_url (valid URL, max 500)
- `UserController::updateProfile` — dedicated profile update action with email verification reset on change
- `User` model — `bio` and `avatar_url` added to fillable + `UserResource` updated
- Migration adding composite index `(user_id, updated_at)` on items table
- Migration adding `bio` and `avatar_url` columns to users table

### Frontend
- `ActivityLogModal` component with `useCursorPagination` hook
- `NotificationCentre` component with polling, mark read, dismiss
- `ProfileModal` extended with bio textarea (char counter) and avatar URL input
- `fetchActivityLog`, notification API functions added to `api.ts`
- `User` type updated with `bio` and `avatar_url` fields

### Tests
- `ActivityLogTest` — 7 tests (pagination, ordering, per_page cap, user scoping, cursor nav, auth)
- `NotificationCentreTest` — 6 tests (dismiss own/others, unread count, mark read, timestamps, auth)
- `UserProfileTest` — 9 tests (view, update bio/avatar, validation, clear, patch, email reset, auth)

## Test plan
- [x] Backend tests pass (566 passed)
- [x] Frontend tests pass (62 passed)
- [x] Pint passes (213 files)
- [x] ESLint passes (0 warnings)
- [x] Prettier passes
- [x] TypeScript typecheck passes
- [x] Frontend build succeeds

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)