### PR TITLE
Refine frontend typography and drag handle

### DIFF
--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -12,22 +12,6 @@
     --text: #0b1324;
   }
 
-  @font-face {
-    font-family: "Virgil";
-    src: url("/fonts/excalidraw/Virgil.woff2") format("woff2");
-    font-style: normal;
-    font-weight: 400;
-    font-display: swap;
-  }
-
-  @font-face {
-    font-family: "Cascadia";
-    src: url("/fonts/excalidraw/Cascadia.woff2") format("woff2");
-    font-style: normal;
-    font-weight: 400;
-    font-display: swap;
-  }
-
   html,
   body {
     height: 100%;
@@ -35,14 +19,21 @@
 
   body {
     @apply bg-[var(--page-bg)] text-[var(--text)] antialiased;
+  }
+
+  .font-ui {
     font-family:
-      var(--font-architects-daughter),
-      "Virgil",
-      "Cascadia",
-      "Segoe Print",
-      "Bradley Hand",
-      "Comic Sans MS",
-      "Chalkboard SE",
+      var(--font-ui),
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      Roboto,
+      sans-serif;
+  }
+
+  .font-reading {
+    font-family:
+      var(--font-reading),
       -apple-system,
       BlinkMacSystemFont,
       "Segoe UI",

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,14 +1,18 @@
 import type { Metadata, Viewport } from "next";
-import { Architects_Daughter } from "next/font/google";
 import "./globals.css";
+import { Inter, Source_Sans_3 } from "next/font/google";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ServiceWorkerRegistration } from "@/components/ServiceWorkerRegistration";
 
-const architectsDaughter = Architects_Daughter({
-  variable: "--font-architects-daughter",
-  weight: "400",
+const inter = Inter({
   subsets: ["latin"],
-  display: "swap",
+  variable: "--font-ui",
+});
+
+const sourceSans = Source_Sans_3({
+  subsets: ["latin"],
+  variable: "--font-reading",
+  weight: ["400", "600", "700"],
 });
 
 export const metadata: Metadata = {
@@ -38,7 +42,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${architectsDaughter.variable} min-h-dvh bg-[var(--page-bg)] text-[var(--text)]`}
+        className={`${inter.variable} ${sourceSans.variable} min-h-dvh bg-[var(--page-bg)] text-[var(--text)] font-ui`}
       >
         <ServiceWorkerRegistration />
         <AuthProvider>

--- a/apps/frontend/src/components/ActivityLogModal.tsx
+++ b/apps/frontend/src/components/ActivityLogModal.tsx
@@ -168,7 +168,7 @@ export function ActivityLogModal({ isOpen, onClose }: ActivityLogModalProps) {
                   className="flex items-start gap-3 p-3 rounded-lg bg-gray-50 border border-gray-100"
                 >
                   <div className="min-w-0 flex-1">
-                    <p className="text-sm font-medium text-gray-900 truncate">
+                    <p className="font-reading text-sm font-medium text-gray-900 truncate">
                       {item.title}
                     </p>
                     <div className="flex items-center gap-2 mt-1">

--- a/apps/frontend/src/components/ItemForm.tsx
+++ b/apps/frontend/src/components/ItemForm.tsx
@@ -160,7 +160,7 @@ export function ItemForm({
                 Description
               </label>
               <textarea
-                className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm transition-all duration-200 focus:border-[var(--blue)] focus:ring-2 focus:ring-[var(--blue)]/20 focus:outline-none resize-none w-full"
+                className="font-reading rounded-md border border-slate-300 bg-white px-3 py-2 text-sm transition-all duration-200 focus:border-[var(--blue)] focus:ring-2 focus:ring-[var(--blue)]/20 focus:outline-none resize-none w-full"
                 rows={3}
                 placeholder="Add more details..."
                 value={description}
@@ -259,7 +259,7 @@ export function ItemForm({
                       My Notes
                     </label>
                     <textarea
-                      className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm transition-all duration-200 focus:border-[var(--blue)] focus:ring-2 focus:ring-[var(--blue)]/20 focus:outline-none resize-none w-full"
+                      className="font-reading rounded-md border border-slate-300 bg-white px-3 py-2 text-sm transition-all duration-200 focus:border-[var(--blue)] focus:ring-2 focus:ring-[var(--blue)]/20 focus:outline-none resize-none w-full"
                       rows={2}
                       placeholder="Add your notes about this task..."
                       value={assigneeNotes}
@@ -272,7 +272,7 @@ export function ItemForm({
                     <label className="block text-xs font-medium text-slate-500 mb-1">
                       Assignee Notes
                     </label>
-                    <p className="text-sm text-slate-600 bg-slate-50 rounded-md px-3 py-2">
+                    <p className="font-reading rounded-md bg-slate-50 px-3 py-2 text-sm text-slate-600">
                       {initial.assignee_notes}
                     </p>
                   </div>

--- a/apps/frontend/src/components/ItemRow.tsx
+++ b/apps/frontend/src/components/ItemRow.tsx
@@ -170,7 +170,7 @@ export function ItemRow({
       {/* Task details */}
       <div className="flex-1 min-w-0">
         <div
-          className={`flex items-center gap-1 font-medium transition-colors duration-200 ${isCompleted || isCancelled ? "text-slate-400 line-through" : "text-[var(--navy)]"}`}
+          className={`font-reading flex items-center gap-1 font-medium transition-colors duration-200 ${isCompleted || isCancelled ? "text-slate-400 line-through" : "text-[var(--navy)]"}`}
         >
           {optimisticItem.title}
           {dates &&
@@ -253,7 +253,7 @@ export function ItemRow({
         </div>
         {optimisticItem.description && (
           <div
-            className={`text-sm mt-1 transition-colors duration-200 ${isCompleted || isCancelled ? "text-slate-300" : "text-slate-500"}`}
+            className={`font-reading mt-1 text-sm transition-colors duration-200 ${isCompleted || isCancelled ? "text-slate-300" : "text-slate-500"}`}
           >
             {optimisticItem.description.length > 50
               ? `${optimisticItem.description.slice(0, 50)}...`
@@ -262,7 +262,7 @@ export function ItemRow({
         )}
         {delegation && optimisticItem.assignee_notes && (
           <div
-            className={`text-sm mt-1 italic transition-colors duration-200 ${isCompleted || isCancelled ? "text-slate-300" : "text-slate-400"}`}
+            className={`font-reading text-sm mt-1 italic transition-colors duration-200 ${isCompleted || isCancelled ? "text-slate-300" : "text-slate-400"}`}
           >
             <span className="text-xs font-medium not-italic text-slate-500">
               Note:{" "}
@@ -318,7 +318,7 @@ export function ItemRow({
       >
         {!isFirst && (
           <button
-            className="tap-target rounded-md bg-slate-100 px-2 py-1 text-slate-700 transition-all duration-200 hover:bg-slate-200 active:scale-95"
+            className="tap-target inline-flex size-8 min-h-8 min-w-8 flex-none items-center justify-center rounded-md bg-slate-100 text-slate-700 transition-all duration-200 hover:bg-slate-200 active:scale-95"
             onClick={() => onMove("top")}
             aria-label="Move to top"
           >
@@ -326,10 +326,23 @@ export function ItemRow({
           </button>
         )}
         <span
-          className="tap-target rounded-md bg-slate-100 px-2 py-1 text-slate-700 transition-all duration-200 hover:bg-slate-200 active:scale-95 cursor-grab"
+          className="tap-target inline-flex size-8 min-h-8 min-w-8 flex-none items-center justify-center rounded-md bg-slate-100 text-slate-500 transition-all duration-200 hover:bg-slate-200 hover:text-slate-700 active:scale-95 cursor-grab"
           aria-label="Drag to reorder"
         >
-          ☰
+          <svg
+            viewBox="0 0 24 24"
+            width="16"
+            height="16"
+            fill="currentColor"
+            className="block"
+          >
+            <circle cx="8" cy="7" r="1.4" />
+            <circle cx="16" cy="7" r="1.4" />
+            <circle cx="8" cy="12" r="1.4" />
+            <circle cx="16" cy="12" r="1.4" />
+            <circle cx="8" cy="17" r="1.4" />
+            <circle cx="16" cy="17" r="1.4" />
+          </svg>
         </span>
       </div>
     </div>

--- a/apps/frontend/src/components/NotesModal.tsx
+++ b/apps/frontend/src/components/NotesModal.tsx
@@ -150,7 +150,7 @@ export function NotesModal({ isOpen, onClose }: NotesModalProps) {
             onChange={(e) => setNotes(e.target.value.slice(0, MAX_CHARS))}
             onBlur={() => saveNotes(notes)}
             placeholder="Jot down anything..."
-            className="w-full min-h-[400px] max-h-[80vh] resize-y rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-300 focus:outline-none focus:ring-1 focus:ring-blue-300"
+            className="font-reading w-full min-h-[400px] max-h-[80vh] resize-y rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-300 focus:outline-none focus:ring-1 focus:ring-blue-300"
           />
 
           {/* Character counter */}


### PR DESCRIPTION
## Summary\n- switch Ballistic UI to Inter by default with Source Sans 3 for item descriptions, notes, and activity log content\n- replace the drag handle glyph with a centered 6-dot grip icon\n- make the reorder controls explicitly square fixed-size buttons in the flex row\n\n## Validation\n- npm run typecheck\n- npm run build\n