### PR TITLE
fix: use updated_at for wontdo activity log items

### DIFF
--- a/apps/frontend/src/__tests__/activity-log-modal.test.ts
+++ b/apps/frontend/src/__tests__/activity-log-modal.test.ts
@@ -1,0 +1,32 @@
+import { getActivityTimestamp } from "@/components/ActivityLogModal";
+import type { ActivityLogEntry } from "@/types";
+
+describe("getActivityTimestamp", () => {
+  test("uses updated_at for wontdo items", () => {
+    const entry: ActivityLogEntry = {
+      id: "1",
+      title: "Skipped task",
+      status: "wontdo",
+      project_id: null,
+      project: null,
+      completed_at: "2026-03-10T08:00:00Z",
+      updated_at: "2026-03-12T14:30:00Z",
+    };
+
+    expect(getActivityTimestamp(entry)).toBe("2026-03-12T14:30:00Z");
+  });
+
+  test("prefers completed_at for done items", () => {
+    const entry: ActivityLogEntry = {
+      id: "2",
+      title: "Finished task",
+      status: "done",
+      project_id: null,
+      project: null,
+      completed_at: "2026-03-11T09:15:00Z",
+      updated_at: "2026-03-12T14:30:00Z",
+    };
+
+    expect(getActivityTimestamp(entry)).toBe("2026-03-11T09:15:00Z");
+  });
+});

--- a/apps/frontend/src/components/ActivityLogModal.tsx
+++ b/apps/frontend/src/components/ActivityLogModal.tsx
@@ -63,7 +63,7 @@ export function ActivityLogModal({ isOpen, onClose }: ActivityLogModalProps) {
   const groups = useMemo(() => {
     const map = new Map<string, ActivityLogEntry[]>();
     for (const entry of items) {
-      const ts = entry.completed_at ?? entry.updated_at;
+      const ts = getActivityTimestamp(entry);
       const key = ts.slice(0, 10); // YYYY-MM-DD
       const bucket = map.get(key);
       if (bucket) bucket.push(entry);
@@ -201,10 +201,18 @@ function ActivityRow({ entry }: { entry: ActivityLogEntry }) {
         )}
       </div>
       <time className="shrink-0 text-[11px] text-gray-400">
-        {formatTime(entry.completed_at ?? entry.updated_at)}
+        {formatTime(getActivityTimestamp(entry))}
       </time>
     </li>
   );
+}
+
+export function getActivityTimestamp(entry: ActivityLogEntry): string {
+  if (entry.status === "wontdo") {
+    return entry.updated_at;
+  }
+
+  return entry.completed_at ?? entry.updated_at;
 }
 
 function ActivityLogSkeleton() {


### PR DESCRIPTION
## Summary
- use a status-aware activity timestamp in the activity log modal
- render and group wontdo items by updated_at instead of completed_at
- add a regression test for done vs wontdo timestamp selection

## Testing
- npm test -- --runInBand src/__tests__/activity-log-modal.test.ts
- npm run typecheck