### PR TITLE
fix: allow mcp stdio bootstrapping

### DIFF
--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -11,10 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Admin API surface reduction** — removed the orphaned `GET /api/admin/stats` and `GET /api/admin/stats/user-activity` endpoints because the supported admin health dashboard already serves equivalent operational metrics via Inertia
 - **Generated admin route helpers** — removed the unused backend Wayfinder helper for the deleted admin stats endpoints
+- **MCP STDIO bootstrap** — local `artisan mcp:start ballistic` sessions now boot without HTTP auth so `initialize`, `tools/list`, and `resources/list` work for Inspector and smoke-test flows; HTTP `/mcp` auth and feature-flag enforcement remain unchanged
+- **MCP verification docs/script** — replaced stale `APP_SERVICE=model_a` examples with `APP_SERVICE=laravel.test` so local verification matches the current Sail service name
 
 ### Tests
 
 - **`AdminTest`**: replaced admin stats assertions with regression coverage proving the removed admin stats API routes now return `404` while admin user routes remain protected
+- **`BallisticServerTest`**: added coverage for STDIO boot bypass and preserved HTTP auth enforcement
 
 ## [0.17.02] - 2026-03-10
 

--- a/apps/backend/app/Mcp/Servers/BallisticServer.php
+++ b/apps/backend/app/Mcp/Servers/BallisticServer.php
@@ -22,6 +22,7 @@ use App\Mcp\Tools\SearchItemsTool;
 use App\Mcp\Tools\UpdateItemTool;
 use App\Mcp\Tools\UpdateProjectTool;
 use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Transport\StdioTransport;
 
 /**
  * Ballistic Social MCP Server.
@@ -172,6 +173,10 @@ final class BallisticServer extends Server
      */
     public function boot(): void
     {
+        if ($this->transport instanceof StdioTransport) {
+            return;
+        }
+
         $user = request()->user();
 
         if (! $user) {

--- a/apps/backend/docs/MCP.md
+++ b/apps/backend/docs/MCP.md
@@ -180,7 +180,7 @@ curl -X POST http://localhost/mcp \
 ./mcp-verify.sh install
 
 # Test STDIO transport
-APP_SERVICE=model_a ./mcp-verify.sh stdio
+APP_SERVICE=laravel.test ./mcp-verify.sh stdio
 
 # Test HTTP transport
 MCP_AUTH_TOKEN='your-token' ./mcp-verify.sh http
@@ -483,7 +483,7 @@ Verify with MCP Inspector:
 For local development and CLI integration, use the STDIO transport:
 
 ```bash
-APP_SERVICE=model_a sail artisan mcp:start ballistic
+APP_SERVICE=laravel.test sail artisan mcp:start ballistic
 ```
 
 This starts an interactive session reading JSON-RPC from stdin and writing to stdout.

--- a/apps/backend/mcp-verify.sh
+++ b/apps/backend/mcp-verify.sh
@@ -7,7 +7,7 @@
 #
 # Prerequisites:
 # - Node.js 18+ and npm installed
-# - Sail container running (APP_SERVICE=model_a ./vendor/bin/sail up -d)
+# - Sail container running (APP_SERVICE=laravel.test ./vendor/bin/sail up -d)
 # - A test user with a Sanctum token
 #
 # Usage:
@@ -86,7 +86,7 @@ EOF
     log_info "Sending test messages to STDIO server..."
 
     # Run the MCP server via artisan and capture output
-    timeout 10 APP_SERVICE=model_a "$SAIL" artisan mcp:start ballistic < "$TEMP_INPUT" > "$TEMP_OUTPUT" 2>&1 || true
+    env APP_SERVICE=laravel.test timeout 10 "$SAIL" artisan mcp:start ballistic < "$TEMP_INPUT" > "$TEMP_OUTPUT" 2>&1 || true
 
     # Check for expected responses
     if grep -q '"serverInfo"' "$TEMP_OUTPUT" 2>/dev/null; then

--- a/apps/backend/tests/Unit/Mcp/BallisticServerTest.php
+++ b/apps/backend/tests/Unit/Mcp/BallisticServerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Mcp;
+
+use App\Mcp\Servers\BallisticServer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Server\Contracts\Transport\Transport;
+use Laravel\Mcp\Server\Transport\StdioTransport;
+use ReflectionProperty;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Tests\TestCase;
+
+final class BallisticServerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_boot_allows_stdio_sessions_without_http_authentication(): void
+    {
+        $server = new BallisticServer;
+        $this->setTransport($server, new StdioTransport);
+        $server->boot();
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_boot_requires_authenticated_http_requests(): void
+    {
+        $server = new BallisticServer;
+        $this->setTransport($server, new class implements Transport
+        {
+            public function onReceive(callable $handler): void {}
+
+            public function send(string $message, ?string $sessionId = null): void {}
+
+            public function run(): void {}
+
+            public function sessionId(): ?string
+            {
+                return null;
+            }
+
+            public function stream(\Closure $stream): void
+            {
+                $stream();
+            }
+        });
+
+        try {
+            $server->boot();
+            $this->fail('Expected boot() to reject unauthenticated HTTP requests.');
+        } catch (HttpException $exception) {
+            $this->assertSame(401, $exception->getStatusCode());
+        }
+    }
+
+    private function setTransport(BallisticServer $server, Transport $transport): void
+    {
+        $property = new ReflectionProperty($server, 'transport');
+        $property->setAccessible(true);
+        $property->setValue($server, $transport);
+    }
+}


### PR DESCRIPTION
## Summary
- allow `artisan mcp:start ballistic` to boot over STDIO without HTTP auth, while keeping HTTP `/mcp` auth enforcement unchanged
- add regression coverage for STDIO boot bypass and HTTP auth rejection
- update MCP verification docs and scripts to use `APP_SERVICE=laravel.test`

## Validation
- `timeout 1800s ./runtests.sh` (apps/backend)
- `timeout 1800s ./runtests.sh --filter=BallisticServerTest` (apps/backend)
- `timeout 1800s ./runtests.sh --filter=McpServerTest` (apps/backend)
- raw STDIO smoke run against `env APP_SERVICE=laravel.test ./vendor/bin/sail artisan mcp:start ballistic`
- `timeout 900s ./vendor/bin/sail php vendor/bin/pint --test` (apps/backend)

## Notes
- the raw STDIO command now returns `initialize`, `tools/list`, and `resources/list` successfully
- `apps/backend` `npm run types` still has pre-existing unrelated failures in `resources/js/pages/dashboard.tsx` and `resources/js/pages/settings/appearance.tsx`