### PR TITLE
fix: use actual wontdo cancellation timestamps in activity log

### DIFF
--- a/apps/backend/app/Http/Controllers/ActivityLogController.php
+++ b/apps/backend/app/Http/Controllers/ActivityLogController.php
@@ -25,6 +25,8 @@ final class ActivityLogController extends Controller
         $perPage = min((int) $request->input('per_page', 20), 50);
         $userId = (string) Auth::id();
 
+        $activityTimestampExpression = "CASE WHEN status = 'wontdo' THEN updated_at ELSE completed_at END";
+
         $items = Item::query()
             ->where(function ($query) use ($userId): void {
                 $query->where('user_id', $userId)
@@ -32,7 +34,9 @@ final class ActivityLogController extends Controller
             })
             ->whereIn('status', ['done', 'wontdo'])
             ->with(['project', 'assignee', 'user'])
-            ->orderByDesc('completed_at')
+            ->select('items.*')
+            ->selectRaw("{$activityTimestampExpression} as activity_sort_at")
+            ->orderByDesc('activity_sort_at')
             ->orderByDesc('updated_at')
             ->cursorPaginate($perPage);
 
@@ -43,11 +47,13 @@ final class ActivityLogController extends Controller
             ->map(function (Item $item) use ($activityMetadata, $request, $userId): array {
                 $metadata = $activityMetadata[$item->id] ?? [];
 
+                $fallbackActivityAt = $item->status === 'wontdo'
+                    ? $item->updated_at?->toIso8601String()
+                    : $item->completed_at?->toIso8601String();
+
                 $item->setAttribute(
                     'activity_at',
-                    $metadata['activity_at']
-                        ?? $item->completed_at?->toIso8601String()
-                        ?? $item->updated_at?->toIso8601String()
+                    $metadata['activity_at'] ?? $fallbackActivityAt ?? $item->updated_at?->toIso8601String()
                 );
                 $item->setAttribute('completed_by', $metadata['completed_by'] ?? null);
                 $item->setAttribute(

--- a/apps/backend/app/Http/Controllers/ItemController.php
+++ b/apps/backend/app/Http/Controllers/ItemController.php
@@ -254,7 +254,7 @@ final class ItemController extends Controller
         // Auto-manage completed_at based on status changes.
         if (isset($validated['status'])) {
             if (in_array($validated['status'], ['done', 'wontdo'], true)
-                && ! in_array($item->status, ['done', 'wontdo'], true)) {
+                && $validated['status'] !== $item->status) {
                 $validated['completed_at'] = now();
             } elseif (in_array($validated['status'], ['todo', 'doing'], true)
                 && in_array($item->status, ['done', 'wontdo'], true)) {

--- a/apps/backend/app/Mcp/Tools/UpdateItemTool.php
+++ b/apps/backend/app/Mcp/Tools/UpdateItemTool.php
@@ -168,7 +168,7 @@ final class UpdateItemTool extends Tool
 
             // Track completion
             if (isset($updateData['status'])) {
-                if (in_array($updateData['status'], ['done', 'wontdo']) && $item->completed_at === null) {
+                if (in_array($updateData['status'], ['done', 'wontdo']) && $updateData['status'] !== $item->status) {
                     $updateData['completed_at'] = now();
                 } elseif (in_array($updateData['status'], ['todo', 'doing']) && $item->completed_at !== null) {
                     $updateData['completed_at'] = null;

--- a/apps/backend/tests/Feature/ActivityLogTest.php
+++ b/apps/backend/tests/Feature/ActivityLogTest.php
@@ -9,6 +9,7 @@ use App\Models\Item;
 use App\Models\Project;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
 final class ActivityLogTest extends TestCase
@@ -60,24 +61,24 @@ final class ActivityLogTest extends TestCase
             ]);
     }
 
-    public function test_activity_log_orders_by_completion_time_descending(): void
+    public function test_activity_log_orders_by_actual_activity_time_descending(): void
     {
         $user = User::factory()->create();
 
-        $oldest = Item::factory()->create([
+        $doneItem = Item::factory()->create([
             'user_id' => $user->id,
             'project_id' => null,
             'status' => 'done',
-            'completed_at' => now()->subDays(2),
-            'updated_at' => now()->subDays(2),
+            'completed_at' => Carbon::parse('2026-03-09 11:00:00'),
+            'updated_at' => Carbon::parse('2026-03-09 11:00:00'),
         ]);
 
-        $newest = Item::factory()->create([
+        $wontdoItem = Item::factory()->create([
             'user_id' => $user->id,
             'project_id' => null,
             'status' => 'wontdo',
-            'completed_at' => now(),
-            'updated_at' => now(),
+            'completed_at' => Carbon::parse('2026-03-01 08:00:00'),
+            'updated_at' => Carbon::parse('2026-03-10 10:00:00'),
         ]);
 
         $response = $this->actingAs($user)
@@ -85,8 +86,9 @@ final class ActivityLogTest extends TestCase
 
         $response->assertStatus(200);
         $data = $response->json('data');
-        $this->assertEquals($newest->id, $data[0]['id']);
-        $this->assertEquals($oldest->id, $data[1]['id']);
+        $this->assertEquals($wontdoItem->id, $data[0]['id']);
+        $this->assertEquals($doneItem->id, $data[1]['id']);
+        $this->assertSame('2026-03-10T10:00:00+00:00', $data[0]['activity_at']);
     }
 
     public function test_activity_log_respects_per_page_parameter(): void
@@ -212,6 +214,28 @@ final class ActivityLogTest extends TestCase
         $response = $this->getJson('/api/activity-log');
 
         $response->assertStatus(401);
+    }
+
+    public function test_activity_log_prefers_cancellation_timestamp_when_no_audit_log_exists(): void
+    {
+        $user = User::factory()->create();
+
+        $item = Item::factory()->create([
+            'user_id' => $user->id,
+            'project_id' => null,
+            'status' => 'wontdo',
+            'completed_at' => Carbon::parse('2026-03-01 08:00:00'),
+            'updated_at' => Carbon::parse('2026-03-10 10:00:00'),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/activity-log');
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'id' => $item->id,
+                'activity_at' => '2026-03-10T10:00:00+00:00',
+            ]);
     }
 
     public function test_activity_log_includes_assignment_context_and_actor(): void

--- a/apps/backend/tests/Feature/ItemTest.php
+++ b/apps/backend/tests/Feature/ItemTest.php
@@ -9,6 +9,7 @@ use App\Models\Project;
 use App\Models\User;
 use App\Services\RecurrenceService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
 final class ItemTest extends TestCase
@@ -164,6 +165,31 @@ final class ItemTest extends TestCase
         $item->refresh();
 
         $this->assertNotNull($item->completed_at);
+    }
+
+    public function test_switching_from_done_to_wontdo_refreshes_completed_at(): void
+    {
+        $user = User::factory()->create();
+        $item = Item::factory()->create([
+            'user_id' => $user->id,
+            'status' => 'done',
+            'completed_at' => Carbon::parse('2026-03-09 11:00:00'),
+            'updated_at' => Carbon::parse('2026-03-09 11:00:00'),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->patchJson("/api/items/{$item->id}", [
+                'status' => 'wontdo',
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'status' => 'wontdo',
+            ]);
+
+        $item->refresh();
+
+        $this->assertTrue($item->completed_at->greaterThan(Carbon::parse('2026-03-09 11:00:00')));
     }
 
     public function test_user_can_delete_their_item(): void

--- a/apps/backend/tests/Feature/McpServerTest.php
+++ b/apps/backend/tests/Feature/McpServerTest.php
@@ -11,6 +11,7 @@ use App\Models\Project;
 use App\Models\Tag;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
 final class McpServerTest extends TestCase
@@ -1262,6 +1263,34 @@ final class McpServerTest extends TestCase
         $item->refresh();
 
         $this->assertNull($item->completed_at);
+    }
+
+    public function test_update_item_refreshes_completed_at_when_switching_from_done_to_wontdo(): void
+    {
+        $item = Item::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'done',
+            'completed_at' => Carbon::parse('2026-03-09 11:00:00'),
+            'updated_at' => Carbon::parse('2026-03-09 11:00:00'),
+        ]);
+
+        $response = $this->withToken($this->token)->postJson('/mcp', [
+            'jsonrpc' => '2.0',
+            'id' => 1151,
+            'method' => 'tools/call',
+            'params' => [
+                'name' => 'update_item',
+                'arguments' => [
+                    'id' => $item->id,
+                    'status' => 'wontdo',
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(200);
+        $item->refresh();
+
+        $this->assertTrue($item->completed_at->greaterThan(Carbon::parse('2026-03-09 11:00:00')));
     }
 
     public function test_update_item_syncs_tags(): void

--- a/apps/backend/tests/Unit/Mcp/McpToolsTest.php
+++ b/apps/backend/tests/Unit/Mcp/McpToolsTest.php
@@ -18,6 +18,7 @@ use App\Models\Project;
 use App\Models\Tag;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Laravel\Mcp\Server\Tools\ToolResult;
 use Tests\TestCase;
 
@@ -246,6 +247,29 @@ final class McpToolsTest extends TestCase
 
         $item->refresh();
         $this->assertNull($item->completed_at);
+    }
+
+    public function test_update_item_tool_refreshes_completed_at_when_switching_from_done_to_wontdo(): void
+    {
+        $item = Item::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'done',
+            'completed_at' => Carbon::parse('2026-03-09 11:00:00'),
+            'updated_at' => Carbon::parse('2026-03-09 11:00:00'),
+        ]);
+
+        $tool = new UpdateItemTool($this->auth);
+
+        $result = $tool->handle([
+            'id' => (string) $item->id,
+            'status' => 'wontdo',
+        ]);
+
+        $resultArray = $result->toArray();
+        $this->assertFalse($resultArray['isError']);
+
+        $item->refresh();
+        $this->assertTrue($item->completed_at->greaterThan(Carbon::parse('2026-03-09 11:00:00')));
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary
- order activity log items by a status-aware activity timestamp so wontdo items sort by cancellation time
- use updated_at as the fallback activity timestamp for wontdo items when no audit log entry exists
- refresh completed_at when switching between done and wontdo in both HTTP and MCP update paths
- add regression coverage for activity ordering and done->wontdo transitions

## Testing
- apps/frontend: npm run test:ci -- --runInBand src/__tests__/activity-log-modal.test.tsx
- apps/frontend: npm run typecheck
- backend PHP tests to be verified by CI on this PR