### PR TITLE
fix(activity-log): preserve cancellation chronology

### DIFF
--- a/apps/backend/app/Http/Controllers/ActivityLogController.php
+++ b/apps/backend/app/Http/Controllers/ActivityLogController.php
@@ -25,7 +25,7 @@ final class ActivityLogController extends Controller
         $perPage = min((int) $request->input('per_page', 20), 50);
         $userId = (string) Auth::id();
 
-        $activityTimestampExpression = "CASE WHEN status = 'wontdo' THEN updated_at ELSE completed_at END";
+        $activityTimestampExpression = "CASE WHEN status = 'wontdo' THEN COALESCE(completed_at, updated_at) ELSE completed_at END";
 
         $items = Item::query()
             ->where(function ($query) use ($userId): void {

--- a/apps/backend/tests/Feature/ActivityLogTest.php
+++ b/apps/backend/tests/Feature/ActivityLogTest.php
@@ -224,8 +224,8 @@ final class ActivityLogTest extends TestCase
             'user_id' => $user->id,
             'project_id' => null,
             'status' => 'wontdo',
-            'completed_at' => Carbon::parse('2026-03-01 08:00:00'),
-            'updated_at' => Carbon::parse('2026-03-10 10:00:00'),
+            'completed_at' => Carbon::parse('2026-03-10 10:00:00'),
+            'updated_at' => Carbon::parse('2026-03-11 12:00:00'),
         ]);
 
         $response = $this->actingAs($user)
@@ -236,6 +236,38 @@ final class ActivityLogTest extends TestCase
                 'id' => $item->id,
                 'activity_at' => '2026-03-10T10:00:00+00:00',
             ]);
+    }
+
+    public function test_activity_log_uses_completed_at_for_cancelled_items_when_no_audit_log_exists(): void
+    {
+        $user = User::factory()->create();
+
+        $cancelledEarlier = Item::factory()->create([
+            'user_id' => $user->id,
+            'project_id' => null,
+            'status' => 'wontdo',
+            'completed_at' => Carbon::parse('2026-03-10 10:00:00'),
+            'updated_at' => Carbon::parse('2026-03-11 12:00:00'),
+        ]);
+
+        $cancelledLater = Item::factory()->create([
+            'user_id' => $user->id,
+            'project_id' => null,
+            'status' => 'wontdo',
+            'completed_at' => Carbon::parse('2026-03-10 11:00:00'),
+            'updated_at' => Carbon::parse('2026-03-10 11:00:00'),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/activity-log');
+
+        $response->assertStatus(200);
+
+        $data = $response->json('data');
+        $this->assertEquals($cancelledLater->id, $data[0]['id']);
+        $this->assertEquals($cancelledEarlier->id, $data[1]['id']);
+        $this->assertSame('2026-03-10T11:00:00+00:00', $data[0]['activity_at']);
+        $this->assertSame('2026-03-10T10:00:00+00:00', $data[1]['activity_at']);
     }
 
     public function test_activity_log_includes_assignment_context_and_actor(): void


### PR DESCRIPTION
## Summary
- fix activity log sorting for cancelled items to prefer completed_at and only fall back to updated_at
- add regression coverage for cancelled items edited after cancellation

## Why
The recent change switched cancelled-item ordering to updated_at. That breaks chronological history if a cancelled item is later edited (for example notes/tag changes), because the item jumps ahead of items actually cancelled later.

## Notes
- I could not run the Laravel test suite in this environment because `php` is not installed here.
- Added a regression test that would fail on current master and pass with this patch.