### PR TITLE
test: restore activity_at coverage for activity log ordering

### DIFF
--- a/apps/backend/tests/Feature/ActivityLogTest.php
+++ b/apps/backend/tests/Feature/ActivityLogTest.php
@@ -88,6 +88,8 @@ final class ActivityLogTest extends TestCase
         $data = $response->json('data');
         $this->assertEquals($doneItem->id, $data[0]['id']);
         $this->assertEquals($wontdoItem->id, $data[1]['id']);
+        $this->assertSame($doneItem->completed_at->toIso8601String(), $data[0]['activity_at']);
+        $this->assertSame($wontdoItem->completed_at->toIso8601String(), $data[1]['activity_at']);
         $this->assertSame($wontdoItem->completed_at->toIso8601String(), $data[1]['completed_at']);
     }
 


### PR DESCRIPTION
## Summary
- restore the `activity_at` assertions in the activity log ordering test
- keep the new cancellation ordering behaviour covered
- avoid a false green where ordering could regress while `completed_at` still passes

## Why
The recent fix changes ordering/fallback behaviour in `ActivityLogController`, but the updated test no longer asserts `activity_at`, which is the API field the endpoint computes and sorts around. That weakens regression protection for the bug this commit was meant to fix.

## Verification
- attempted to run `apps/backend/runtests.sh tests/Feature/ActivityLogTest.php`
- blocked because `apps/backend/vendor/bin/sail` is absent in a fresh clone (dependencies not bootstrapped on this host)
