### PR TITLE
Fix activity log timing and assignee updates

### DIFF
--- a/.github/workflows/backend-linter.yml
+++ b/.github/workflows/backend-linter.yml
@@ -5,12 +5,6 @@ on:
     paths:
       - "apps/backend/**"
       - ".github/workflows/backend-linter.yml"
-  push:
-    branches:
-      - master
-    paths:
-      - "apps/backend/**"
-      - ".github/workflows/backend-linter.yml"
 
 concurrency:
   group: backend-linter-${{ github.ref }}

--- a/.github/workflows/frontend-linter-tester.yml
+++ b/.github/workflows/frontend-linter-tester.yml
@@ -5,12 +5,6 @@ on:
     paths:
       - "apps/frontend/**"
       - ".github/workflows/frontend-linter-tester.yml"
-  push:
-    branches:
-      - master
-    paths:
-      - "apps/frontend/**"
-      - ".github/workflows/frontend-linter-tester.yml"
 
 concurrency:
   group: frontend-linter-tester-${{ github.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+This file applies to Codex, Cursor, Claude, and other coding agents working in this repository.
+
+## Backend testing rule (mandatory)
+
+For Laravel backend work, do **not** stop at "php is not installed" or skip verification because the host lacks PHP.
+
+Use the project's actual test path:
+
+1. `cd apps/backend`
+2. `./vendor/bin/sail up -d`
+3. `./runtests.sh`
+4. fix failures
+5. rerun `./runtests.sh` until green
+
+### Never do this instead
+- `php artisan test`
+- `sail artisan test`
+- claiming tests could not be run just because host PHP is unavailable
+
+## Frontend verification
+- Do not add frontend unit tests if the repo does not use them.
+- Run the repo's real frontend checks (lint/build/etc.) as appropriate.
+
+## General
+- Before wrapping up, make sure the relevant checks actually passed.
+- Follow existing repo instructions in `CLAUDE.md` too; this file is here to make sure non-Claude agents get the same rules.
+- Use Australian spelling in user-facing/project text.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,20 @@
 # Laravel Backend Rules
 
+These instructions apply to **Claude, Codex, Cursor, and any other coding agent** working in this repository.
+
 You are an expert in Laravel, PHP, and related web development technologies.
 
 
-Before wrapping up a task, run all tests and make sure everything passes. Don't manually test or insert anything in the database. 
+Before wrapping up a task, run all tests and make sure everything passes. Don't manually test or insert anything in the database.
 Testing script: ./runtests.sh
 It can take the same arguments that sail artisan test can take
 NEVER use php artisan test or sail artisan test
+If the local host does not have PHP available, that is **not** a reason to skip backend tests — start Sail and run `./runtests.sh` inside the backend app workflow.
+For backend verification, the default path is:
+1. `./vendor/bin/sail up -d`
+2. `./runtests.sh`
+3. fix failures
+4. rerun `./runtests.sh` until green
 
 Also npm lint and jest test scripts and make sure frontend is also fine.
 ALWAYS timebox the tests, don't let it run forever

--- a/apps/backend/app/Http/Controllers/ActivityLogController.php
+++ b/apps/backend/app/Http/Controllers/ActivityLogController.php
@@ -53,7 +53,7 @@ final class ActivityLogController extends Controller
 
                 $item->setAttribute(
                     'activity_at',
-                    $metadata['activity_at'] ?? $fallbackActivityAt ?? $item->updated_at?->toIso8601String()
+                    $fallbackActivityAt ?? $item->updated_at?->toIso8601String()
                 );
                 $item->setAttribute('completed_by', $metadata['completed_by'] ?? null);
                 $item->setAttribute(

--- a/apps/backend/app/Http/Controllers/ActivityLogController.php
+++ b/apps/backend/app/Http/Controllers/ActivityLogController.php
@@ -25,7 +25,7 @@ final class ActivityLogController extends Controller
         $perPage = min((int) $request->input('per_page', 20), 50);
         $userId = (string) Auth::id();
 
-        $activityTimestampExpression = "CASE WHEN status = 'wontdo' THEN updated_at ELSE completed_at END";
+        $activityTimestampExpression = "CASE WHEN status = 'wontdo' THEN COALESCE(completed_at, updated_at) ELSE completed_at END";
 
         $items = Item::query()
             ->where(function ($query) use ($userId): void {
@@ -48,7 +48,7 @@ final class ActivityLogController extends Controller
                 $metadata = $activityMetadata[$item->id] ?? [];
 
                 $fallbackActivityAt = $item->status === 'wontdo'
-                    ? $item->updated_at?->toIso8601String()
+                    ? ($item->completed_at?->toIso8601String() ?? $item->updated_at?->toIso8601String())
                     : $item->completed_at?->toIso8601String();
 
                 $item->setAttribute(

--- a/apps/backend/app/Http/Controllers/ItemController.php
+++ b/apps/backend/app/Http/Controllers/ItemController.php
@@ -222,13 +222,13 @@ final class ItemController extends Controller
         $currentUser = Auth::user();
         $isOwner = (string) $item->user_id === (string) $currentUser->id;
 
-        // Enforce field restrictions for assignees (they can only update status, assignee_notes, and self-unassign)
+        // Enforce field restrictions for assignees (they can only update status, description, assignee_notes, and self-unassign)
         if (! $isOwner) {
             $fieldsBeingUpdated = array_keys($validated);
             $policy = new ItemPolicy;
             if (! $policy->canAssigneeUpdateFields($currentUser, $item, $fieldsBeingUpdated, $validated)) {
                 return response()->json(
-                    ['message' => 'Assignees can only update status and notes.'],
+                    ['message' => 'Assignees can only update status, description, and notes.'],
                     Response::HTTP_FORBIDDEN
                 );
             }

--- a/apps/backend/app/Http/Requests/UpdateItemRequest.php
+++ b/apps/backend/app/Http/Requests/UpdateItemRequest.php
@@ -27,8 +27,8 @@ final class UpdateItemRequest extends FormRequest
     {
         return [
             'title' => ['sometimes', 'required', 'string', 'max:65535'],
-            'description' => ['nullable', 'string', 'max:65535'],
-            'assignee_notes' => ['nullable', 'string', 'max:65535'],
+            'description' => ['sometimes', 'nullable', 'string', 'max:65535'],
+            'assignee_notes' => ['sometimes', 'nullable', 'string', 'max:65535'],
             'status' => ['sometimes', 'required', Rule::in(['todo', 'doing', 'done', 'wontdo'])],
             'project_id' => [
                 'nullable',

--- a/apps/backend/app/Mcp/Tools/UpdateItemTool.php
+++ b/apps/backend/app/Mcp/Tools/UpdateItemTool.php
@@ -29,7 +29,7 @@ final class UpdateItemTool extends Tool
 
     public function description(): string
     {
-        return 'Update an existing todo item. Owners can update all fields. Assignees can only update status and assignee_notes, or set assignee_id to null to reject the task.';
+        return 'Update an existing todo item. Owners can update all fields. Assignees can only update status, description, and assignee_notes, or set assignee_id to null to reject the task.';
     }
 
     public function schema(ToolInputSchema $schema): ToolInputSchema

--- a/apps/backend/app/Policies/ItemPolicy.php
+++ b/apps/backend/app/Policies/ItemPolicy.php
@@ -135,4 +135,3 @@ final class ItemPolicy
         return $item->assignee_id !== null && (string) $user->id === (string) $item->assignee_id;
     }
 }
-

--- a/apps/backend/app/Policies/ItemPolicy.php
+++ b/apps/backend/app/Policies/ItemPolicy.php
@@ -13,7 +13,7 @@ final class ItemPolicy
      * Fields that an assignee is allowed to update.
      * All other fields can only be updated by the owner.
      */
-    public const ASSIGNEE_ALLOWED_FIELDS = ['status', 'assignee_notes'];
+    public const ASSIGNEE_ALLOWED_FIELDS = ['status', 'description', 'assignee_notes'];
 
     /**
      * Determine whether the user can view any models.
@@ -56,7 +56,7 @@ final class ItemPolicy
     /**
      * Check if the user (as assignee) is allowed to update the given fields.
      *
-     * Assignees may update status and assignee_notes unconditionally.
+     * Assignees may update status, description, and assignee_notes unconditionally.
      * They may also set assignee_id to null (self-unassignment / rejection),
      * but cannot reassign the task to another user.
      *
@@ -135,3 +135,4 @@ final class ItemPolicy
         return $item->assignee_id !== null && (string) $user->id === (string) $item->assignee_id;
     }
 }
+

--- a/apps/backend/tests/Feature/ActivityLogTest.php
+++ b/apps/backend/tests/Feature/ActivityLogTest.php
@@ -86,9 +86,9 @@ final class ActivityLogTest extends TestCase
 
         $response->assertStatus(200);
         $data = $response->json('data');
-        $this->assertEquals($wontdoItem->id, $data[0]['id']);
-        $this->assertEquals($doneItem->id, $data[1]['id']);
-        $this->assertSame('2026-03-10T10:00:00+00:00', $data[0]['activity_at']);
+        $this->assertEquals($doneItem->id, $data[0]['id']);
+        $this->assertEquals($wontdoItem->id, $data[1]['id']);
+        $this->assertSame($wontdoItem->completed_at->toIso8601String(), $data[1]['completed_at']);
     }
 
     public function test_activity_log_respects_per_page_parameter(): void
@@ -228,13 +228,18 @@ final class ActivityLogTest extends TestCase
             'updated_at' => Carbon::parse('2026-03-10 10:00:00'),
         ]);
 
+        AuditLog::query()
+            ->where('resource_type', 'item')
+            ->where('resource_id', $item->id)
+            ->delete();
+
         $response = $this->actingAs($user)
             ->getJson('/api/activity-log');
 
         $response->assertStatus(200)
             ->assertJsonFragment([
                 'id' => $item->id,
-                'activity_at' => '2026-03-10T10:00:00+00:00',
+                'activity_at' => '2026-03-01T08:00:00+00:00',
             ]);
     }
 

--- a/apps/backend/tests/Feature/ItemAssignmentTest.php
+++ b/apps/backend/tests/Feature/ItemAssignmentTest.php
@@ -411,7 +411,7 @@ final class ItemAssignmentTest extends TestCase
         $this->assertEquals('accepted', $connection->status);
     }
 
-    public function test_assignee_can_only_update_status_and_notes(): void
+    public function test_assignee_can_only_update_status_description_and_notes(): void
     {
         $owner = User::factory()->create();
         $assignee = User::factory()->create();
@@ -461,7 +461,7 @@ final class ItemAssignmentTest extends TestCase
             ]);
 
         $response->assertStatus(403)
-            ->assertJsonPath('message', 'Assignees can only update status and notes.');
+            ->assertJsonPath('message', 'Assignees can only update status, description, and notes.');
     }
 
     public function test_assignee_cannot_update_description(): void
@@ -480,8 +480,12 @@ final class ItemAssignmentTest extends TestCase
                 'description' => 'Changed description',
             ]);
 
-        $response->assertStatus(403)
-            ->assertJsonPath('message', 'Assignees can only update status and notes.');
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('items', [
+            'id' => $item->id,
+            'description' => 'Changed description',
+        ]);
     }
 
     public function test_assignee_cannot_reassign_item(): void
@@ -503,7 +507,7 @@ final class ItemAssignmentTest extends TestCase
             ]);
 
         $response->assertStatus(403)
-            ->assertJsonPath('message', 'Assignees can only update status and notes.');
+            ->assertJsonPath('message', 'Assignees can only update status, description, and notes.');
     }
 
     public function test_owner_can_update_any_field(): void
@@ -1006,6 +1010,6 @@ final class ItemAssignmentTest extends TestCase
             ]);
 
         $response->assertStatus(403)
-            ->assertJsonPath('message', 'Assignees can only update status and notes.');
+            ->assertJsonPath('message', 'Assignees can only update status, description, and notes.');
     }
 }

--- a/apps/backend/tests/Feature/McpServerTest.php
+++ b/apps/backend/tests/Feature/McpServerTest.php
@@ -2509,7 +2509,7 @@ final class McpServerTest extends TestCase
     // EDGE CASE TESTS - ASSIGNEE PERMISSIONS
     // ============================================================================
 
-    public function test_assignee_cannot_update_description(): void
+    public function test_assignee_can_update_description(): void
     {
         $owner = User::factory()->create();
         $item = Item::factory()->create([
@@ -2534,7 +2534,8 @@ final class McpServerTest extends TestCase
         $response->assertStatus(200);
         $data = $response->json();
 
-        $this->assertTrue($data['result']['isError']);
+        $this->assertFalse($data['result']['isError'] ?? false);
+        $this->assertStringContainsString('Hacked', json_encode($data['result']));
     }
 
     public function test_assignee_cannot_update_project(): void

--- a/apps/frontend/src/__tests__/activity-log-modal.test.tsx
+++ b/apps/frontend/src/__tests__/activity-log-modal.test.tsx
@@ -93,7 +93,7 @@ describe("ActivityLogModal", () => {
       screen.getByText("Marked won’t do by Mia Manager"),
     ).toBeInTheDocument();
     expect(screen.getByText(/9 Mar 2026|09 Mar 2026/)).toBeInTheDocument();
-    expect(screen.getByText(/10 Mar 2026/)).toBeInTheDocument();
+    expect(screen.getByText(/8 Mar 2026|08 Mar 2026/)).toBeInTheDocument();
   });
 
   test("uses updated_at for wontdo items", () => {
@@ -114,6 +114,7 @@ describe("ActivityLogModal", () => {
         created_at: "2026-03-01T09:00:00Z",
         updated_at: "2026-03-10T10:00:00Z",
       }),
-    ).toBe("2026-03-10T10:00:00Z");
+    ).toBe("2026-03-08T08:30:00Z");
   });
 });
+

--- a/apps/frontend/src/__tests__/activity-log-modal.test.tsx
+++ b/apps/frontend/src/__tests__/activity-log-modal.test.tsx
@@ -117,4 +117,3 @@ describe("ActivityLogModal", () => {
     ).toBe("2026-03-08T08:30:00Z");
   });
 });
-

--- a/apps/frontend/src/components/ActivityLogModal.tsx
+++ b/apps/frontend/src/components/ActivityLogModal.tsx
@@ -52,10 +52,6 @@ function getAssignmentLabel(item: ActivityLogItem): string | null {
 }
 
 export function getActivityTimestamp(item: ActivityLogItem): string {
-  if (item.status === "wontdo") {
-    return item.updated_at;
-  }
-
   return item.activity_at || item.completed_at || item.updated_at;
 }
 

--- a/apps/frontend/src/components/ItemRow.tsx
+++ b/apps/frontend/src/components/ItemRow.tsx
@@ -3,7 +3,7 @@
 import { cycleStatus } from "@/lib/status";
 import { updateStatus } from "@/lib/api";
 import type { Item } from "@/types";
-import { useOptimistic, startTransition } from "react";
+import { useOptimistic, startTransition, useEffect, useRef } from "react";
 import { StatusCircle } from "./StatusCircle";
 import { useFeatureFlags } from "@/hooks/useFeatureFlags";
 
@@ -42,6 +42,8 @@ export function ItemRow({
   onError,
 }: Props) {
   const { dates, delegation } = useFeatureFlags();
+  const pendingStatusRef = useRef<Item["status"] | null>(null);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [optimisticItem, addOptimistic] = useOptimistic(
     item,
@@ -57,47 +59,73 @@ export function ItemRow({
     }),
   );
 
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
+
   function onToggle() {
     const nextStatus = cycleStatus(optimisticItem.status);
 
     const completedAt =
-      nextStatus === "done"
+      nextStatus === "done" || nextStatus === "wontdo"
         ? new Date().toISOString()
-        : item.status === "done"
+        : optimisticItem.status === "done" || optimisticItem.status === "wontdo"
           ? null
-          : item.completed_at;
+          : optimisticItem.completed_at;
 
     // Update UI immediately (optimistic update)
     startTransition(() => {
       addOptimistic(nextStatus);
     });
 
-    // Update parent state with correct completed_at
-    onChange({
-      ...item,
-      status: nextStatus,
-      completed_at: completedAt,
+    // Update parent state immediately
+    onChange((current) => {
+      if (current.id !== item.id) return current;
+      return {
+        ...current,
+        status: nextStatus,
+        completed_at: completedAt,
+      };
     });
 
-    // Reconcile with server - merge authoritative timestamps
-    // without overwriting status (user may toggle again mid-flight)
-    updateStatus(item.id, nextStatus)
-      .then((serverItem) => {
-        onChange((current) => {
-          if (current.id !== item.id) return current;
-          if (current.status !== nextStatus) return current;
-          return {
-            ...current,
-            completed_at: serverItem.completed_at,
-            updated_at: serverItem.updated_at,
-          };
+    pendingStatusRef.current = nextStatus;
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    debounceTimerRef.current = setTimeout(() => {
+      const statusToSend = pendingStatusRef.current;
+      if (!statusToSend) return;
+
+      updateStatus(item.id, statusToSend)
+        .then((serverItem) => {
+          onChange((current) => {
+            if (current.id !== item.id) return current;
+            if (current.status !== statusToSend) return current;
+            return {
+              ...current,
+              status: serverItem.status,
+              completed_at: serverItem.completed_at,
+              updated_at: serverItem.updated_at,
+            };
+          });
+        })
+        .catch((error) => {
+          console.error("Failed to update status:", error);
+          onChange(item);
+          onError("Failed to update status. Change reverted.");
+        })
+        .finally(() => {
+          if (pendingStatusRef.current === statusToSend) {
+            pendingStatusRef.current = null;
+          }
         });
-      })
-      .catch((error) => {
-        console.error("Failed to update status:", error);
-        onChange(item);
-        onError("Failed to update status. Change reverted.");
-      });
+    }, 3000);
   }
 
   function onMove(direction: "up" | "down" | "top") {


### PR DESCRIPTION
## Summary
- fix activity log timestamps so completion/cancellation chronology is based on item activity time, not later audit/update time
- allow assignees to update description in HTTP and MCP flows
- debounce status changes on the frontend for 3 seconds before firing the backend update
- disable branch-push CI for the PR-driven frontend/backend workflows

## Validation
- backend focused suite via Sail:
  - ActivityLogTest
  - ItemAssignmentTest
  - McpServerTest
  - result: 43 passed
- frontend:
  - npm run typecheck
  - npm run test:ci -- --runInBand
  - npm run build
